### PR TITLE
Auto-Hiss на русском для ящеров и таяр.

### DIFF
--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -42,16 +42,16 @@
 
 /datum/species/unathi
 	autohiss_basic_map = list(
-			"s" = list("ss", "sss", "ssss")
+			"ס" = list("סס", "סס", "ססס")
 		)
 	autohiss_extra_map = list(
-			"x" = list("ks", "kss", "ksss")
+			"ק" = list("ש", "שש", "ששש")
 		)
 	autohiss_exempt = list(LANGUAGE_UNATHI)
 
 /datum/species/tajaran
 	autohiss_basic_map = list(
-			"r" = list("rr", "rrr", "rrrr")
+			"נ" = list("ננ", "נננ", "ננננ")
 		)
 	autohiss_exempt = list(LANGUAGE_SIIK_MAAS)
 


### PR DESCRIPTION
autohiss_extra для ящеров локализован как (ч= "щ" "щщ" "щщщ") вместо (х= "ks" "kss" "ksss")