### PR TITLE
Портирование функции автоматического подбора руды с Paradise

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -558,6 +558,7 @@ var/list/mining_floors = list()
 				A = get_step(src, direction)
 				A.updateMineralOverlays()
 
+/*	We've got new collect method code for ore satchel. ~Quardbreak
 /turf/simulated/floor/asteroid/Entered(atom/movable/M as mob|obj)
 	..()
 	if(istype(M,/mob/living/silicon/robot))
@@ -570,4 +571,4 @@ var/list/mining_floors = list()
 			else if(istype(R.module_state_3,/obj/item/weapon/storage/ore))
 				attackby(R.module_state_3,R)
 			else
-				return
+				return */

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -7,19 +7,42 @@
 	var/datum/geosample/geologic_data
 	var/ore/ore = null // set to a type to find the right instance on init
 
-	New()
-		..()
-		if(ispath(ore))
-			ensure_ore_data_initialised()
-			ore = ores_by_type[ore]
-			if(ore.ore != type)
-				world.log << "[src] ([src.type]) had ore type [ore.type] but that type does not have [src.type] set as its ore item!"
-			update_ore()
+/obj/item/weapon/ore/New()
+	..()
+	if(ispath(ore))
+		ensure_ore_data_initialised()
+		ore = ores_by_type[ore]
+		if(ore.ore != type)
+			world.log << "[src] ([src.type]) had ore type [ore.type] but that type does not have [src.type] set as its ore item!"
+		update_ore()
 
-	proc/update_ore()
-		name = ore.display_name
-		icon_state = "ore_[ore.icon_tag]"
-		origin_tech = ore.origin_tech.Copy()
+/obj/item/weapon/ore/proc/update_ore()
+	name = ore.display_name
+	icon_state = "ore_[ore.icon_tag]"
+	origin_tech = ore.origin_tech.Copy()
+
+/obj/item/weapon/ore/Crossed(AM as mob|obj)
+	var/obj/item/weapon/storage/ore/OB
+	var/turf/simulated/floor/F = get_turf(src)
+	if(loc != F)
+		return ..()
+	if(ishuman(AM))
+		var/mob/living/carbon/human/H = AM
+		OB = H.is_in_hands(/obj/item/weapon/storage/ore)
+		if(!OB)
+			if(istype(H.s_store, /obj/item/weapon/storage/ore))
+				OB = H.s_store
+			else if(istype(H.belt, /obj/item/weapon/storage/ore))
+				OB = H.belt
+	else if(isrobot(AM))
+		var/mob/living/silicon/robot/R = AM
+		for(var/thing in R.get_all_slots())
+			if(istype(thing, /obj/item/weapon/storage/ore))
+				OB = thing
+				break
+	if(OB && istype(F, /turf/simulated/floor/asteroid))
+		F.attackby(OB, AM)
+	return ..()
 
 /obj/item/weapon/ore/slag
 	name = "Slag"

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -256,3 +256,6 @@ var/list/slot_equipment_priority = list( \
 	for(var/entry in get_equipped_items(include_carried))
 		drop_from_inventory(entry)
 		qdel(entry)
+
+/mob/proc/get_all_slots()
+ 	return list(wear_mask, back, l_hand, r_hand)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -29,6 +29,13 @@ This saves us from having to call add_fingerprint() any time something is put in
 		qdel(W)
 	return null
 
+/mob/living/carbon/human/proc/is_in_hands(var/typepath)
+	if(istype(l_hand,typepath))
+		return l_hand
+	if(istype(r_hand,typepath))
+		return r_hand
+	return 0
+
 //Puts the item into our active hand if possible. returns 1 on success.
 /mob/living/carbon/human/put_in_active_hand(var/obj/item/W)
 	return (hand ? put_in_l_hand(W) : put_in_r_hand(W))
@@ -411,3 +418,4 @@ This saves us from having to call add_fingerprint() any time something is put in
 		if(slot_r_store)    . += r_store
 		if(slot_handcuffed) . += handcuffed
 		if(slot_s_store)    . += s_store
+


### PR DESCRIPTION
### Изменения:
- Портирование функции автоматического подбора руды с репозитория ParadiseSS13 (ссылка на оригинальный запрос слияния https://github.com/ParadiseSS13/Paradise/pull/3680)
- Если во время пересечении тайла с находящимися на нём рудами носить в руках/на поясе шахтёрскую сумку для руд, вся руда будет автоматически перемещаться в сумку.
- Небольшое обновление стиля строения кода для функций `New()` и `proc/update_ore()` рудной сумки.
- Добавлены проверочные функции `get_all_slots` для ветки `/mob/`, is_in_hands для ветки `/mob/living/carbon/human/`.