### PR TITLE
Улучшение агрессивных мобов

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -235,5 +235,5 @@
 					obstacle.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
 					return
 			var/obj/structure/obstacle = locate(/obj/structure, get_step(src, dir))
-			if(istype(obstacle, /obj/structure/window) || istype(obstacle, /obj/structure/closet) || istype(obstacle, /obj/structure/table) || istype(obstacle, /obj/structure/grille))
+			if(istype(obstacle, /obj/structure/window) || istype(obstacle, /obj/structure/closet) || istype(obstacle, /obj/structure/table) || istype(obstacle, /obj/structure/grille || istype(obstacle, /obj/structure/wall_frame) || istype(obstacle, /obj/structure/sandbag) || istype(obstacle, /obj/structure/barrier) || istype(obstacle, /obj/structure/handrail) || istype(obstacle, /obj/structure/door_assembly) || istype(obstacle, /obj/machinery/door) || istype(obstacle, /obj/item/tape) || istype(obstacle, /obj/machinery/deployable/barrier) || istype(obstacle, /obj/structure/barricade) || istype(obstacle, /obj/structure/girder) || istype(obstacle, /obj/structure/inflatable))
 				obstacle.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)


### PR DESCRIPTION
Добавил агрессивным мобам возможность ломать: низкие стенки (те, что под окнами), баррикады (деревянные и переносные), барьеры, надувные стенки, строящиеся и целые двери, поручни, ленты, гирдеры стен. Это сделает их чуть более опасными, так как теперь они могут проламываться в комнаты даже если там стоят разного вида баррикады и окна.