### PR TITLE
Шлюз будет пищать при отказе в доступе даже если недостаточно защищён

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -790,13 +790,15 @@ About the new airlock wires panel:
 			if(density && src.arePowerSystemsOn())
 				set_airlock_overlays(AIRLOCK_DENY)
 				flick("deny", src)
-				if(secured_wires)
-					playsound(src.loc, open_failure_access_denied, 50, 0)
+				//if(secured_wires)
+				playsound(src.loc, open_failure_access_denied, 50, 0)
 				update_icon(AIRLOCK_CLOSED)
 		if("emag")
 			if(density && src.arePowerSystemsOn())
 				set_airlock_overlays(AIRLOCK_EMAG)
 				flick("deny", src)
+				//if(secured_wires)
+				playsound(src.loc, open_failure_access_denied, 50, 0)
 		else
 			update_icon()
 	return


### PR DESCRIPTION
Что нового:
* Теперь шлюзы вне зависимости от степени защищённости платы (secured_wires) будут отзываться и пищать при отказе в доступе. Плюс, при взломе с помощью емаг-секвенсора будет сопровождаться аналогичный звук