### PR TITLE
[READY] Разнёрф телепортационных заклинаний мага

### DIFF
--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -4,10 +4,10 @@
 	feedback = "BL"
 	school = "conjuration"
 	charge_max = 20
-	spell_flags = Z2NOCAST | IGNOREDENSE | IGNORESPACE
+	spell_flags = Z2NOCAST | IGNOREDENSE | IGNORESPACE | NO_SOMATIC
 	invocation = "none"
 	invocation_type = SpI_NONE
-	range = 7
+	range = 14 // infinity-ss13: old first number - 7
 	inner_radius = 1
 
 	level_max = list(Sp_TOTAL = 4, Sp_SPEED = 4, Sp_POWER = 4)
@@ -26,12 +26,14 @@
 		user.forceMove(T)
 
 		var/datum/effect/effect/system/smoke_spread/smoke = new /datum/effect/effect/system/smoke_spread()
-		smoke.set_up(3, 0, starting)
+		smoke.set_up(10, 0, starting) // infinity-ss13: old first number - 5
 		smoke.start()
 
+		/* infinity-ss13
 		smoke = new()
 		smoke.set_up(3, 0, T)
 		smoke.start()
+		*/
 
 	return
 


### PR DESCRIPTION
Что нового:
* В целях баланса маг снова может использовать заклинание Blink если закован или оглушён
* Радиус действия Blink'а изменён с 7 до 14
* Размер дымовой завесы увеличен
* Убрана дымовая завеса на месте назначения