### PR TITLE
Бордюрные аварийные створки

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -1,6 +1,10 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
 #define DOOR_REPAIR_AMOUNT 50	//amount of health regained per stack amount used
 
+//A = thing to open, B = how long until opening, C = if the opening is forced.
+#define OPEN_IN(A, B, C) addtimer(CALLBACK(A, /obj/machinery/door/proc/open, C), B)
+#define CLOSE_IN(A, B, C) addtimer(CALLBACK(A, /obj/machinery/door/proc/close, C), B)
+
 /obj/machinery/door
 	name = "Door"
 	desc = "It opens and closes."

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -167,11 +167,9 @@
 			// Accountability!
 			users_to_open |= user.name
 			needs_to_close = !issilicon(user)
-		spawn()
-			open()
+		OPEN_IN(src, 0, FALSE)
 	else
-		spawn()
-			close()
+		CLOSE_IN(src, 0, FALSE)
 
 	if(needs_to_close)
 		spawn(50)
@@ -254,11 +252,9 @@
 						"You force \the [ blocked ? "welded" : "" ] [src] [density ? "open" : "closed"] with \the [C]!",\
 						"You hear metal strain and groan, and a door [density ? "opening" : "closing"].")
 			if(density)
-				spawn(0)
-					open(1)
+				OPEN_IN(src, 0, TRUE)
 			else
-				spawn(0)
-					close()
+				CLOSE_IN(src, 0, FALSE)
 			return
 		else
 			to_chat(user, "<span class='notice'>You must remain still to interact with \the [src].</span>")
@@ -432,46 +428,42 @@
 	overlays += weld_overlay
 	overlays += lights_overlay
 
-//These are playing merry hell on ZAS.  Sorry fellas :(
-
+//Single direction firedoors.
 /obj/machinery/door/firedoor/border_only
-/*
 	icon = 'icons/obj/doors/edge_Doorfire.dmi'
 	glass = 1 //There is a glass window so you can see through the door
 			  //This is needed due to BYOND limitations in controlling visibility
 	heat_proof = 1
 	air_properties_vary_with_direction = 1
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-		if(istype(mover) && mover.checkpass(PASS_FLAG_GLASS))
-			return 1
-		if(get_dir(loc, target) == dir) //Make sure looking at appropriate border
-			if(air_group) return 0
-			return !density
-		else
-			return 1
-
-	CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
-		if(istype(mover) && mover.checkpass(PASS_FLAG_GLASS))
-			return 1
-		if(get_dir(loc, target) == dir)
-			return !density
-		else
-			return 1
-
-
-	update_nearby_tiles(need_rebuild)
-		if(!air_master) return 0
-
-		var/turf/simulated/source = loc
-		var/turf/simulated/destination = get_step(source,dir)
-
-		update_heat_protection(loc)
-
-		if(istype(source)) air_master.tiles_to_update += source
-		if(istype(destination)) air_master.tiles_to_update += destination
+/obj/machinery/door/firedoor/border_only/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if(istype(mover) && mover.checkpass(PASS_FLAG_GLASS))
 		return 1
-*/
+	if(get_dir(loc, target) == dir) //Make sure looking at appropriate border
+		if(air_group) return 0
+		return !density
+	else
+		return 1
+
+/obj/machinery/door/firedoor/border_only/CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
+	if(istype(mover) && mover.checkpass(PASS_FLAG_GLASS))
+		return 1
+	if(get_dir(loc, target) == dir)
+		return !density
+	else
+		return 1
+
+
+/obj/machinery/door/firedoor/border_only/update_nearby_tiles(need_rebuild)
+
+	var/turf/simulated/source = get_turf(src)
+	var/turf/simulated/destination = get_step(source,dir)
+
+	update_heat_protection(loc)
+
+	if(istype(source)) SSair.mark_for_update(source)
+	if(istype(destination)) SSair.mark_for_update(destination)
+	return 1
 
 /obj/machinery/door/firedoor/multi_tile
 	icon = 'icons/obj/doors/DoorHazard2x1.dmi'

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -7,6 +7,7 @@ obj/structure/firedoor_assembly
 	opacity = 0
 	density = 1
 	var/wired = 0
+	var/result = /obj/machinery/door/firedoor
 
 obj/structure/firedoor_assembly/on_update_icon()
 	if(anchored)
@@ -41,7 +42,9 @@ obj/structure/firedoor_assembly/attackby(C as obj, mob/user as mob)
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 			user.visible_message("<span class='warning'>[user] has inserted a circuit into \the [src]!</span>",
 								  "You have inserted the circuit into \the [src]!")
-			new /obj/machinery/door/firedoor(src.loc)
+			var/obj/O = new result(src.loc)
+			O.dir = src.dir
+
 			qdel(C)
 			qdel(src)
 		else
@@ -67,3 +70,23 @@ obj/structure/firedoor_assembly/attackby(C as obj, mob/user as mob)
 			to_chat(user, "<span class='notice'>You need more welding fuel.</span>")
 	else
 		..(C, user)
+
+/obj/structure/firedoor_assembly/border_only
+	name = "unidirectional emergency shutter assembly"
+	result = /obj/machinery/door/firedoor/border_only
+
+/obj/structure/firedoor_assembly/border_only/verb/rotate_clock()
+	set category = "Object"
+	set name = "Rotate Assembly (Clockwise)"
+	set src in view(1)
+	if (usr.incapacitated() || anchored)
+		return
+ 	set_dir(turn(dir, -90))
+
+/obj/structure/firedoor_assembly/border_only/verb/rotate_anticlock()
+	set category = "Object"
+	set name = "Rotate Assembly (Counter-clockwise)"
+	set src in view(1)
+	if (usr.incapacitated()|| anchored)
+		return
+	set_dir(turn(dir, 90))

--- a/code/modules/materials/recipes_furniture.dm
+++ b/code/modules/materials/recipes_furniture.dm
@@ -217,9 +217,16 @@ ARMCHAIR(yellow)
 	title = "emergency shutter"
 	result_type = /obj/structure/firedoor_assembly
 
+/datum/stack_recipe/furniture/door_assembly/firedoor/border_only
+	title = "unidirectional emergency shutter"
+	result_type = /obj/structure/firedoor_assembly/border_only
+	req_amount = 2
+
 /datum/stack_recipe/furniture/door_assembly/multi_tile
 	title = "multi-tile airlock assembly"
 	result_type = /obj/structure/door_assembly/multi_tile
+	req_amount = 8
+	time = 10 SECONDS
 
 /datum/stack_recipe/furniture/crate
 	title = "crate"


### PR DESCRIPTION
Что нового:
* Портировал у Чаоко долгожданные исправления бордюрных аварийных створк. Наконец-то они будут работать!
* Форма от двойных шлюзов теперь требует 8 листов металла вместо 4 и затрачивает десять секунд вместо пяти