### PR TITLE
Исправление мгновенного закрытия интерфейса радио

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -761,8 +761,8 @@
 	return
 
 /obj/item/device/radio/off
+	broadcasting = 0
 	listening = 0
-	on = 0
 
 /obj/item/device/radio/announcer
 	invisibility = 101


### PR DESCRIPTION
Что нового:
* В связи с особенностью механики и истинном предназначении переменной `on` было решено заменить её на broadcasting = 0. Это должно исправить проблему с открытием интерфейса (#451) 