### PR TITLE
Изменение способа проверки расы для резоми и ксеноморфов

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -274,7 +274,7 @@
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.species.reagent_tag == IS_XENOS)
+		if(H.get_species() == SPECIES_XENO)
 			H.pry_open(src)
 
 	if(src.allowed(user) && operable())

--- a/code/game/objects/structures/barrier.dm
+++ b/code/game/objects/structures/barrier.dm
@@ -105,7 +105,7 @@
 	return 1
 
 /obj/structure/barrier/attack_hand(mob/living/carbon/human/user as mob)
-	if(user.species.can_shred(user) || user.species.reagent_tag == IS_XENOS)
+	if(user.species.can_shred(user) || user.get_species() == SPECIES_XENO)
 		take_damage(user.species.)
 		return
 	if(deployed)

--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -204,7 +204,7 @@
 		if(M.gender == FEMALE)
 			emote_sound = "sound/voice/cough_female.ogg"
 
-		if(H.species.reagent_tag == IS_RESOMI)
+		if(H.get_species() == SPECIES_RESOMI)
 			emote_sound = "sound/voice/resomicoughb.ogg"
 
 		if(emote_sound)
@@ -295,7 +295,7 @@
 		if(M.gender == FEMALE)
 			emote_sound = "sound/voice/laugh_female_[rand(1,3)].ogg"
 
-		if(H.species.reagent_tag == IS_RESOMI)
+		if(H.get_species() == SPECIES_RESOMI)
 			emote_sound = "sound/voice/resomicougha.ogg"
 
 		if(emote_sound)
@@ -360,10 +360,10 @@
 		if(M.gender == FEMALE)
 			emote_sound = "sound/voice/scream_female_[rand(1,2)].ogg"
 
-		if(H.species.reagent_tag == IS_XENOS)
+		if(H.get_species() == SPECIES_XENO)
 			emote_sound = "sound/voice/alien_pain.ogg"
 
-		if(H.species.reagent_tag == IS_RESOMI)
+		if(H.get_species() == SPECIES_RESOMI)
 			emote_sound = "sound/voice/resomisneeze.ogg"
 
 		if(emote_sound)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -797,11 +797,11 @@ var/global/list/damage_icon_parts = list()
 	var/image/total = new
 	for(var/obj/item/organ/external/E in organs)
 		if(!BP_IS_ROBOTIC(E) && E.how_open())
-			if(E.owner.species.reagent_tag != IS_RESOMI)
-				var/image/I = image("icon"='icons/mob/surgery.dmi', "icon_state"="[E.icon_name][round(E.how_open())]", "layer"=-HO_SURGERY_LAYER)
+			if(E.owner.get_species() == SPECIES_RESOMI)
+				var/image/I = image("icon"='icons/mob/human_races/species/resomi/surgery.dmi', "icon_state"="[E.icon_name][round(E.how_open())]", "layer"=-HO_SURGERY_LAYER)
 				total.overlays += I
 			else
-				var/image/I = image("icon"='icons/mob/human_races/species/resomi/surgery.dmi', "icon_state"="[E.icon_name][round(E.how_open())]", "layer"=-HO_SURGERY_LAYER)
+				var/image/I = image("icon"='icons/mob/surgery.dmi', "icon_state"="[E.icon_name][round(E.how_open())]", "layer"=-HO_SURGERY_LAYER)
 				total.overlays += I
 	total.appearance_flags = RESET_COLOR
 	overlays_standing[HO_SURGERY_LAYER] = total


### PR DESCRIPTION
Что нового:
* Изменена проверка в иконках, барьерах, дверях и эмоутах. Теперь она осуществляется по имени расы, а не по химическому тегу