### PR TITLE
Изменения для призраков

### DIFF
--- a/code/datums/communication/looc.dm
+++ b/code/datums/communication/looc.dm
@@ -45,7 +45,8 @@
 
 /client/proc/receive_looc(var/client/C, var/commkey, var/message, var/prefix)
 	var/mob/M = C.mob
-	var/display_name = isghost(M) ? commkey : M.name
+	var/anonsay_pref = C.get_preference_value(/datum/client_preference/anon_say) == GLOB.PREF_YES ? M.name : commkey
+	var/display_name = isghost(M) ? anonsay_pref : M.name
 	var/admin_stuff = holder ? "/([commkey])" : ""
 	if(prefix)
 		prefix = "\[[prefix]\] "

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -446,6 +446,7 @@ proc/is_blind(A)
 			C = M.original.client
 
 	if(C)
+		if(C.get_preference_value(/datum/client_preference/anon_say) == GLOB.PREF_YES) return
 		var/name
 		if(C.mob)
 			var/mob/M = C.mob

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -595,10 +595,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Set Ghost Alpha"
 	set desc = "Giving you option to enter value for custom ghost transparency"
 	set category = "Ghost"
-	var/input = input("New alpha value (maximum number is 127):",, alpha) as null|num
-	if(!input)
-		return
-	alpha = Clamp(input, 0, 127)
+	alpha = alpha == 127 ? 0 : 127
+	mouse_opacity = alpha ? 1 : 0
 
 /mob/observer/ghost/verb/respawn()
 	set name = "Respawn"


### PR DESCRIPTION
Что нового:
* LOOC уважает настройки анонимности: Если не в игре - отображает имя призрака.
* Появление не отображается в чат при включённой анонимности.
* Переработана кнопка скрытия собственного спрайта.