### PR TITLE
Резоми и Таяры в ЭК + мелочи

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -430,6 +430,7 @@
 
 //Single direction firedoors.
 /obj/machinery/door/firedoor/border_only
+/* //Infinity: We have fixed it, but bs12 are using them on Torch, so, they have no sprite. Sorry.
 	icon = 'icons/obj/doors/edge_Doorfire.dmi'
 	glass = 1 //There is a glass window so you can see through the door
 			  //This is needed due to BYOND limitations in controlling visibility
@@ -464,7 +465,7 @@
 	if(istype(source)) SSair.mark_for_update(source)
 	if(istype(destination)) SSair.mark_for_update(destination)
 	return 1
-
+*/
 /obj/machinery/door/firedoor/multi_tile
 	icon = 'icons/obj/doors/DoorHazard2x1.dmi'
 	width = 2

--- a/maps/torchinf/job/torch_jobs.dm
+++ b/maps/torchinf/job/torch_jobs.dm
@@ -12,7 +12,7 @@
 		/datum/species/unathi  = list(HUMAN_ONLY_JOBS, /datum/job/liaison, /datum/job/warden), //Other jobs unavailable via branch restrictions,
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS),
 		/datum/species/tajaran = list(HUMAN_ONLY_JOBS),
-		/datum/species/resomi  = list(HUMAN_ONLY_JOBS),
+		/datum/species/resomi  = list(HUMAN_ONLY_JOBS, /datum/job/guard, /datum/job/officer, /datum/job/rd, /datum/job/liaison),
 		/datum/species/machine = list(HUMAN_ONLY_JOBS),
 		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/guard, /datum/job/officer, /datum/job/rd, /datum/job/liaison, /datum/job/warden),	//Other jobs unavailable via branch restrictions,
 	)

--- a/maps/torchinf/torch_define.dm
+++ b/maps/torchinf/torch_define.dm
@@ -37,7 +37,7 @@
 	num_exoplanets = 0
 	planet_size = list(129,129)
 
-	away_site_budget = 3
+	away_site_budget = 2
 	id_hud_icons = 'maps/torch/icons/assignment_hud.dmi'
 
 /datum/map/torch/setup_map()

--- a/maps/torchinf/torch_ranks.dm
+++ b/maps/torchinf/torch_ranks.dm
@@ -19,25 +19,25 @@
 	)
 
 	species_to_branch_whitelist = list(
+		/datum/species/adherent   = list(/datum/mil_branch/civilian),
 		/datum/species/diona      = list(/datum/mil_branch/civilian),
 		/datum/species/nabber     = list(/datum/mil_branch/civilian),
 		/datum/species/skrell     = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
-		/datum/species/tajaran    = list(/datum/mil_branch/civilian),
-		/datum/species/resomi     = list(/datum/mil_branch/civilian),
+		/datum/species/tajaran    = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
+		/datum/species/resomi     = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
 		/datum/species/unathi     = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
 		/datum/species/vox        = list(),
-		/datum/species/adherent   = list(/datum/mil_branch/civilian)
 	)
 
 	species_to_branch_blacklist = list(
+		/datum/species/adherent   = list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/solgov),
 		/datum/species/diona      = list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/solgov),
 		/datum/species/nabber     = list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/solgov),
 		/datum/species/skrell     = list(/datum/mil_branch/fleet, /datum/mil_branch/solgov),
-		/datum/species/tajaran    = list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/solgov),
-		/datum/species/resomi     = list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/solgov),
+		/datum/species/tajaran    = list(/datum/mil_branch/fleet, /datum/mil_branch/solgov),
+		/datum/species/resomi     = list(/datum/mil_branch/fleet, /datum/mil_branch/solgov),
 		/datum/species/unathi     = list(/datum/mil_branch/fleet, /datum/mil_branch/solgov),
 		/datum/species/vox        = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/solgov),
-		/datum/species/adherent   = list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/solgov),
 	)
 
 
@@ -70,7 +70,24 @@
 				/datum/mil_rank/ec/o3,
 				/datum/mil_rank/ec/o5,
 				/datum/mil_rank/ec/o6
-
+			)
+		),
+		/datum/species/tajaran = list(
+			/datum/mil_branch/expeditionary_corps = list(
+				/datum/mil_rank/ec/e7,
+				/datum/mil_rank/ec/o3,
+				/datum/mil_rank/ec/o5,
+				/datum/mil_rank/ec/o6
+			)
+		),
+		/datum/species/resomi = list(
+			/datum/mil_branch/expeditionary_corps = list(
+				/datum/mil_rank/ec/e5,
+				/datum/mil_rank/ec/e7,
+				/datum/mil_rank/ec/o1,
+				/datum/mil_rank/ec/o3,
+				/datum/mil_rank/ec/o5,
+				/datum/mil_rank/ec/o6
 			)
 		),
 		/datum/species/unathi = list(
@@ -109,6 +126,18 @@
 				/datum/mil_rank/ec/e3,
 				/datum/mil_rank/ec/e5,
 				/datum/mil_rank/ec/o1
+			)
+		),
+		/datum/species/tajaran = list(
+			/datum/mil_branch/expeditionary_corps = list(
+				/datum/mil_rank/ec/e3,
+				/datum/mil_rank/ec/e5,
+				/datum/mil_rank/ec/o1
+			)
+		),
+		/datum/species/resomi = list(
+			/datum/mil_branch/expeditionary_corps = list(
+				/datum/mil_rank/ec/e3,
 			)
 		),
 		/datum/species/unathi = list(


### PR DESCRIPTION
:cl:
tweak: Резоми и Таяры могут в ЭК.
tweak: Резоми на могут в корпоративную охрану, каптенармусов, корпоративных представителей и РД.
/:cl:

Что по мелочам, так здесь уменьшение количества спавнящихся на овермапе объектов (для повышения производительности) и фикс спрайта противопожарных створок на торче.