### PR TITLE
Улучшение верба who

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -73,7 +73,24 @@
 	else
 		for(var/client/C in GLOB.clients)
 			if(!C.is_stealthed())
-				Lines += C.key
+				var/entry = "[C.key]"
+				switch(C.mob.stat)
+					if(DEAD)
+						if(isghost(C.mob))
+							var/mob/observer/ghost/O = C.mob
+							if(O.started_as_observer)
+								entry += " - <font color='gray'><b>Observing</b></font>"
+							else
+								entry += " - <font color='green'><b>Playing</b></font>"
+						else if(isnewplayer(C.mob))
+							entry += " - <font color='blue'><b>In Lobby</b></font>"
+					else
+						entry += " - <font color='green'><b>Playing</b></font>"
+
+				if(C.is_afk())
+					entry += " - <b>AFK: [C.inactivity2text()]</b>"
+
+				Lines += entry
 
 	for(var/line in sortList(Lines))
 		msg += "[line]\n"


### PR DESCRIPTION
<!-- Большой брат следит за тобой--> 
Изменение верба **who** для простых игроков.  Теперь же игроки могут посмотреть, какой ckey **играет/наблюдает/находится в лобби**. 

**Умершие/загоставшиеся** игроки засчитываются как играющие, тем самым не показывая что они "всё".

С оформлением у дела плохи, поэтому я не знаю, сойдёт ли такое или нет.
![image](https://user-images.githubusercontent.com/29167103/49838950-0425cd80-fdbe-11e8-8b92-c35fcdaff2c5.png)
