### PR TITLE
Secured guns and authorization

### DIFF
--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -7,7 +7,7 @@
 		slot_r_hand_str = 'icons/mob/onmob/items/righthand_guns_secure.dmi',
 		)
 	req_access = list(list(access_brig, access_bridge))
-	authorized_modes = list(ALWAYS_AUTHORIZED, AUTHORIZED)
+	authorized_modes = list(ALWAYS_AUTHORIZED, UNAUTHORIZED)
 
 /obj/item/weapon/gun/energy/stunrevolver/secure
 	name = "A&M X6 stun revolver"
@@ -37,7 +37,7 @@
 		)
 	item_state = null	//so the human update icon uses the icon_state instead.
 	req_access = list(list(access_brig, access_bridge))
-	authorized_modes = list(ALWAYS_AUTHORIZED, AUTHORIZED)
+	authorized_modes = list(ALWAYS_AUTHORIZED, UNAUTHORIZED)
 
 /obj/item/weapon/gun/energy/revolver/secure
 	name = "smart service revolver"
@@ -56,7 +56,7 @@
 		list(mode_name="kill", projectile_type=/obj/item/projectile/beam, modifystate="energyrevolverkill"),
 		)
 	req_access = list(list(access_brig, access_heads))
-	authorized_modes = list(ALWAYS_AUTHORIZED, AUTHORIZED)
+	authorized_modes = list(ALWAYS_AUTHORIZED, UNAUTHORIZED)
 
 /obj/item/weapon/gun/energy/gun/secure/mounted
 	name = "robot energy gun"

--- a/code/modules/projectiles/secure.dm
+++ b/code/modules/projectiles/secure.dm
@@ -27,10 +27,15 @@
 	if(istype(W, /obj/item/weapon/card/id) && is_secure_gun())
 		if(!registered_owner)
 			var/obj/item/weapon/card/id/id = W
-			GLOB.registered_weapons += src
-			verbs += /obj/item/weapon/gun/proc/reset_registration
-			registered_owner = id.registered_name
-			user.visible_message("[user] swipes an ID through \the [src], registering it.", "You swipe an ID through \the [src], registering it.")
+			var/req_access = list(list(access_brig, access_bridge))
+			var/success = has_access(req_access, user.GetAccess())
+			if(success)
+				GLOB.registered_weapons += src
+				verbs += /obj/item/weapon/gun/proc/reset_registration
+				registered_owner = id.registered_name
+				user.visible_message("[user] swipes an ID through \the [src], registering it.", "You swipe an ID through \the [src], registering it.")
+			else
+				to_chat(user, "You haven't ID access for registration this weapon.")
 		else
 			to_chat(user, "This weapon is already registered, you must reset it first.")
 	else


### PR DESCRIPTION
1)Теперь secured пушки требуют регистрации.
2)Зарегистрировать их можно только картами с доступом в бриг или на мостик.
3)Использовать их после регистрации может кто угодно, проверки на карту нет.