### PR TITLE
Телесайнс. Максимальное значение сектора

### DIFF
--- a/infinity/code/modules/telesci/telesci_computer.dm
+++ b/infinity/code/modules/telesci/telesci_computer.dm
@@ -326,7 +326,7 @@
 		var/new_z = input("Please input desired sector.", name, z_co) as num
 		if(..())
 			return
-		z_co = Clamp(round(new_z), 1, 15)
+		z_co = Clamp(round(new_z), 1, 25)
 
 	if(href_list["ejectGPS"])
 		if(inserted_gps)


### PR DESCRIPTION
В телесайнсе нельзя вводить в качестве сектора число более 15, если ввести больше, то в любом случае будет выбран 15 сектор. В данном реквесте допустимое число для сектора повышено до 25.

Пример:
Сектор планеты:17
![Screenshot_40](https://user-images.githubusercontent.com/52353663/60386168-56001d80-9a9a-11e9-8b91-6acf57d52274.png)
Сам сектор разрешен для телепортации, но так как ввести число больше 15 нельзя, то настроить телепад на планету не получится.
