### PR TITLE
ремонт майнкрафта

### DIFF
--- a/infinity/code/modules/materials/reciepes.dm
+++ b/infinity/code/modules/materials/reciepes.dm
@@ -33,7 +33,7 @@
 
 /datum/stack_recipe/mainkraft/beaker
 	title = "iron bowl"
-	result_type = /obj/item/clothing/accessory/armorplate/mainkraft/medium
+	result_type = /obj/item/weapon/reagent_containers/glass/beaker/large/mitoll
 	req_amount = 6
 	difficulty = 1
 	time = 60
@@ -57,4 +57,4 @@
 	. = ..()
 	if(reinforce_material)	//recipies below don't support composite materials
 		return
-	. += create_recipe_list(/datum/stack_recipe/box)
+	. += new/datum/stack_recipe/mainkraft/papercup(src)


### PR DESCRIPTION
раньше по ошибке вместо металлической колбы крафтилась бронепластина
также невозможно было скрафтить бумажный стаканчик
все это сейчас починил, надеюсь
