### PR TITLE
Временное отключение ограничений рюкзака

### DIFF
--- a/infinity/code/game/objects/items/weapons/storage/backpack.dm
+++ b/infinity/code/game/objects/items/weapons/storage/backpack.dm
@@ -30,7 +30,7 @@
 		SPECIES_UNATHI = 'icons/mob/onmob/Unathi/back.dmi'
 		)
 
-	var/worn_access = FALSE
+	var/worn_access = TRUE // temporary buff due to player reviews
 
 /obj/item/weapon/storage/backpack/holding
 	item_icons = list(


### PR DESCRIPTION
Привет, воспользовавшись фидбеком и отзывами я подумал что можно предложить временно отключить данное ограничения для рюкзаков. Функцию оставил т.к. она может пригодиться для каких-то конкретных рюкзаков в будущем.