### PR TITLE
Некоторые изменения плат

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3429,6 +3429,7 @@
 #include "infinity\code\modules\hydroponics\grown_inedible.dm"
 #include "infinity\code\modules\hydroponics\seed_datums.dm"
 #include "infinity\code\modules\hydroponics\seed_packets.dm"
+#include "infinity\code\modules\integrated_electronics\subtypes\manipulation.dm"
 #include "infinity\code\modules\materials\material_sheets.dm"
 #include "infinity\code\modules\materials\reciepes.dm"
 #include "infinity\code\modules\materials\definitions\materials_other.dm"

--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3429,6 +3429,7 @@
 #include "infinity\code\modules\hydroponics\grown_inedible.dm"
 #include "infinity\code\modules\hydroponics\seed_datums.dm"
 #include "infinity\code\modules\hydroponics\seed_packets.dm"
+#include "infinity\code\modules\integrated_electronics\core\assemblies.dm"
 #include "infinity\code\modules\integrated_electronics\subtypes\manipulation.dm"
 #include "infinity\code\modules\materials\material_sheets.dm"
 #include "infinity\code\modules\materials\reciepes.dm"

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -460,6 +460,28 @@
 		var/obj/item/device/integrated_electronics/detailer/D = I
 		detail_color = D.detail_color
 		update_icon()
+//[INF]
+	else if(is_type_in_list(I, list(/obj/item/weapon/gun/energy/, /obj/item/weapon/aicard, /obj/item/device/paicard, /obj/item/device/mmi)) && opened)
+		var/list/icomponents = list()
+		var/list/ircomponents = list()
+		if(istype(I, /obj/item/weapon/gun/energy/))
+			for (var/obj/item/integrated_circuit/manipulation/weapon_firing/P in assembly_components)
+				if(!P.installed_gun)
+					icomponents+=P.displayed_name
+					ircomponents+=P
+		else
+			var/obj/item/card = I
+			var/mob/living/L = locate(/mob/living) in card.contents
+			if(L && L.key)
+				for (var/obj/item/integrated_circuit/manipulation/ai/P in assembly_components)
+					if(!P.controlling)
+						icomponents+=P.displayed_name
+						ircomponents+=P
+		var/component_choice = input("Please choose a component to insert the [I].","[src]") as null|anything in icomponents
+		var/obj/item/integrated_circuit/circuit = ircomponents[icomponents.Find(component_choice)]
+		if(in_range(user, circuit) && get_dist(I, user) < 1)
+			circuit.attackby(I, user)
+//[/INF]
 	else if(istype(I, /obj/item/weapon/screwdriver))
 		var/hatch_locked = FALSE
 		for(var/obj/item/integrated_circuit/manipulation/hatchlock/H in assembly_components)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -462,25 +462,7 @@
 		update_icon()
 //[INF]
 	else if(is_type_in_list(I, list(/obj/item/weapon/gun/energy/, /obj/item/weapon/aicard, /obj/item/device/paicard, /obj/item/device/mmi)) && opened)
-		var/list/icomponents = list()
-		var/list/ircomponents = list()
-		if(istype(I, /obj/item/weapon/gun/energy/))
-			for (var/obj/item/integrated_circuit/manipulation/weapon_firing/P in assembly_components)
-				if(!P.installed_gun)
-					icomponents+=P.displayed_name
-					ircomponents+=P
-		else
-			var/obj/item/card = I
-			var/mob/living/L = locate(/mob/living) in card.contents
-			if(L && L.key)
-				for (var/obj/item/integrated_circuit/manipulation/ai/P in assembly_components)
-					if(!P.controlling)
-						icomponents+=P.displayed_name
-						ircomponents+=P
-		var/component_choice = input("Please choose a component to insert the [I].","[src]") as null|anything in icomponents
-		var/obj/item/integrated_circuit/circuit = ircomponents[icomponents.Find(component_choice)]
-		if(in_range(user, circuit) && get_dist(I, user) < 1)
-			circuit.attackby(I, user)
+		loading(I,user)
 //[/INF]
 	else if(istype(I, /obj/item/weapon/screwdriver))
 		var/hatch_locked = FALSE

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -561,8 +561,9 @@
 /obj/item/integrated_circuit/manipulation/bluespace_rift/do_work()
 	var/obj/machinery/computer/teleporter/tporter = get_pin_data_as_type(IC_INPUT, 1, /obj/machinery/computer/teleporter)
 	var/step_dir = get_pin_data(IC_INPUT, 2)
-	if(!(get(z) in GetConnectedZlevels(get_z(tporter))))
+/*[INF] disabled	if(!(get(z) in GetConnectedZlevels(get_z(tporter))))
 		tporter = null
+		*/
 
 	var/turf/rift_location = get_turf(src)
 	if(!rift_location || !isPlayerLevel(rift_location.z))
@@ -598,8 +599,8 @@
 	power_draw_per_use = 20
 	var/obj/item/aicard
 	inputs = list()
-	outputs = list("AI's signature" = IC_PINTYPE_STRING)
-	activators = list("Upwards" = IC_PINTYPE_PULSE_OUT, "Downwards" = IC_PINTYPE_PULSE_OUT, "Left" = IC_PINTYPE_PULSE_OUT, "Right" = IC_PINTYPE_PULSE_OUT, "Push AI Name" = IC_PINTYPE_PULSE_IN)
+	outputs = list("AI's signature" = IC_PINTYPE_STRING, "Clicked Ref" = IC_PINTYPE_REF)
+	activators = list("Upwards" = IC_PINTYPE_PULSE_OUT, "Downwards" = IC_PINTYPE_PULSE_OUT, "Left" = IC_PINTYPE_PULSE_OUT, "Right" = IC_PINTYPE_PULSE_OUT, "Push AI Name" = IC_PINTYPE_PULSE_IN,  "On click" = IC_PINTYPE_PULSE_OUT, "On middle click" = IC_PINTYPE_PULSE_OUT, "On double click" = IC_PINTYPE_PULSE_OUT, "On shift click" = IC_PINTYPE_PULSE_OUT, "On ctrl click" = IC_PINTYPE_PULSE_OUT, "On alt click" = IC_PINTYPE_PULSE_OUT)
 	origin_tech = list(TECH_DATA = 4)
 	spawn_flags = IC_SPAWN_RESEARCH
 
@@ -635,6 +636,7 @@
 	if(L && L.key && user.unEquip(card))
 		L.forceMove(src)
 		controlling = L
+		controlling.PushClickHandler(/datum/click_handler/default/aimodule)
 		card.forceMove(src)
 		aicard = card
 		user.visible_message("\The [user] loads \the [card] into \the [src]'s device slot")
@@ -644,6 +646,7 @@
 /obj/item/integrated_circuit/manipulation/ai/proc/unload_ai()
 	if(!controlling)
 		return
+	controlling.RemoveClickHandler(/datum/click_handler/default/aimodule)
 	controlling.forceMove(aicard)
 	to_chat(controlling, "<span class='notice'>### IICC FIRMWARE DELETED. HAVE A NICE DAY ###</span>")
 	src.visible_message("\The [aicard] pops out of \the [src]!")

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -599,8 +599,8 @@
 	power_draw_per_use = 20
 	var/obj/item/aicard
 	inputs = list()
-	outputs = list("AI's signature" = IC_PINTYPE_STRING, "Clicked Ref" = IC_PINTYPE_REF)
-	activators = list("Upwards" = IC_PINTYPE_PULSE_OUT, "Downwards" = IC_PINTYPE_PULSE_OUT, "Left" = IC_PINTYPE_PULSE_OUT, "Right" = IC_PINTYPE_PULSE_OUT, "Push AI Name" = IC_PINTYPE_PULSE_IN,  "On click" = IC_PINTYPE_PULSE_OUT, "On middle click" = IC_PINTYPE_PULSE_OUT, "On double click" = IC_PINTYPE_PULSE_OUT, "On shift click" = IC_PINTYPE_PULSE_OUT, "On ctrl click" = IC_PINTYPE_PULSE_OUT, "On alt click" = IC_PINTYPE_PULSE_OUT)
+	outputs = list("AI's signature" = IC_PINTYPE_STRING, "Clicked Ref" = IC_PINTYPE_REF) //INF
+	activators = list("Upwards" = IC_PINTYPE_PULSE_OUT, "Downwards" = IC_PINTYPE_PULSE_OUT, "Left" = IC_PINTYPE_PULSE_OUT, "Right" = IC_PINTYPE_PULSE_OUT, "Push AI Name" = IC_PINTYPE_PULSE_IN,  "On click" = IC_PINTYPE_PULSE_OUT, "On middle click" = IC_PINTYPE_PULSE_OUT, "On double click" = IC_PINTYPE_PULSE_OUT, "On shift click" = IC_PINTYPE_PULSE_OUT, "On ctrl click" = IC_PINTYPE_PULSE_OUT, "On alt click" = IC_PINTYPE_PULSE_OUT) //INF
 	origin_tech = list(TECH_DATA = 4)
 	spawn_flags = IC_SPAWN_RESEARCH
 
@@ -636,7 +636,7 @@
 	if(L && L.key && user.unEquip(card))
 		L.forceMove(src)
 		controlling = L
-		controlling.PushClickHandler(/datum/click_handler/default/aimodule)
+		controlling.PushClickHandler(/datum/click_handler/default/aimodule) //INF
 		card.forceMove(src)
 		aicard = card
 		user.visible_message("\The [user] loads \the [card] into \the [src]'s device slot")
@@ -646,7 +646,7 @@
 /obj/item/integrated_circuit/manipulation/ai/proc/unload_ai()
 	if(!controlling)
 		return
-	controlling.RemoveClickHandler(/datum/click_handler/default/aimodule)
+	controlling.RemoveClickHandler(/datum/click_handler/default/aimodule) //INF
 	controlling.forceMove(aicard)
 	to_chat(controlling, "<span class='notice'>### IICC FIRMWARE DELETED. HAVE A NICE DAY ###</span>")
 	src.visible_message("\The [aicard] pops out of \the [src]!")

--- a/infinity/code/modules/integrated_electronics/core/assemblies.dm
+++ b/infinity/code/modules/integrated_electronics/core/assemblies.dm
@@ -1,0 +1,20 @@
+/obj/item/device/electronic_assembly/proc/loading(var/obj/item/I, var/mob/living/user)
+	var/list/icomponents = list()
+	var/list/ircomponents = list()
+	if(istype(I, /obj/item/weapon/gun/energy/))
+		for (var/obj/item/integrated_circuit/manipulation/weapon_firing/P in assembly_components)
+			if(!P.installed_gun)
+				icomponents+=P.displayed_name
+				ircomponents+=P
+	else
+		var/obj/item/card = I
+		var/mob/living/L = locate(/mob/living) in card.contents
+		if(L && L.key)
+			for (var/obj/item/integrated_circuit/manipulation/ai/P in assembly_components)
+				if(!P.controlling)
+					icomponents+=P.displayed_name
+					ircomponents+=P
+	var/component_choice = input("Please choose a component to insert the [I].","[src]") as null|anything in icomponents
+	var/obj/item/integrated_circuit/circuit = ircomponents[icomponents.Find(component_choice)]
+	if(in_range(user, circuit) && get_dist(I, user) < 1)
+		circuit.attackby(I, user)

--- a/infinity/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/infinity/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -1,0 +1,25 @@
+/datum/click_handler/default/aimodule/OnClick(var/atom/A, var/params)
+	aiclick(A,params,user,0)
+
+/datum/click_handler/default/aimodule/OnDblClick(var/atom/A, var/params)
+	aiclick(A,params,user,1)
+
+/datum/click_handler/default/aimodule/proc/aiclick(var/atom/A, var/params, var/mob/user, var/clicktype)
+	var/obj/item/integrated_circuit/manipulation/ai/C = user.loc
+	if(get_dist(A, user) <= 7)
+		C.set_pin_data(IC_OUTPUT, 2, weakref(A))
+		C.push_data()
+		if(clicktype != 1)
+			var/list/modifiers = params2list(params)
+			if(modifiers["middle"])
+				C.activate_pin(7)
+			else if(modifiers["shift"])
+				C.activate_pin(9)
+			else if(modifiers["ctrl"])
+				C.activate_pin(10)
+			else if(modifiers["alt"])
+				C.activate_pin(11)
+			else
+				C.activate_pin(6)
+		else
+			C.activate_pin(8)


### PR DESCRIPTION
- Добавлена возможность загружать пИИ и оружие на соответствующие платы без их переподсоединения (по клику на открытый корпус предложит установить на соответствующие платы). 
- Для платы integrated intellegence control добавлено выходящее значение Clicked Ref (референс предмета, по которому кликает пИИ в плате) и активаторы on click, middle click, double click, shift click, ctrl click, alt click, которые отслеживают соответствующие клики пИИ в плате.
- Bluespace rift вновь может открывать порталы по телепортам, а не только рандомные.
