### PR TITLE
фикс двойного баллона с азотом

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -120,7 +120,7 @@
 	name = "double emergency nitrogen tank"
 	icon_state = "emergency_double_nitrogen"
 	gauge_icon = "indicator_emergency_double"
-	volume = 90
+	volume = 90 //inf, was 60
 
 /*
  * Nitrogen

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -120,7 +120,7 @@
 	name = "double emergency nitrogen tank"
 	icon_state = "emergency_double_nitrogen"
 	gauge_icon = "indicator_emergency_double"
-	volume = 60
+	volume = 90
 
 /*
  * Nitrogen


### PR DESCRIPTION
У двойного баллона с кислородом объем 90.
У двойного с азотом сейчас - 60.
Произошел коммунизм и баллон с азотом тоже стал объемом как кислородный.


Раньше мне казалось что двойной азотный кончается раза в полтора быстрее чем кислородный, оказалось так и есть. Теперь это пофикшено. Надеюсь.