### PR TITLE
Фикс проверки хирургии для грипперов

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -214,7 +214,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			return TRUE
 
 	// Otherwise we can make a start on surgery!
-	else if(istype(M) && !QDELETED(M) && user.a_intent != I_HURT && user.get_active_hand() == src)
+	else if(istype(M) && !QDELETED(M) && user.a_intent != I_HURT && (user.get_active_hand() == src || istype(src.loc, /mob/living/silicon/) && istype(user.get_active_hand(), /obj/item/weapon/gripper/))) //INF
 		// Double-check this in case it changed between initial check and now.
 		if(zone in M.surgeries_in_progress)
 			to_chat(user, SPAN_WARNING("You can't operate on this area while surgery is already in progress."))


### PR DESCRIPTION
Позволяет боргам вновь вставлять органы через гриппер. (Ранее была проверка наличия вставляемого предмета в активном слоте, что находило сам gripper, а не орган(как должно быть), что отменяло операцию).