### PR TITLE
Апдейт плат 2

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -27,6 +27,7 @@
 	var/static/next_assembly_id = 0
 	var/interact_page = 0
 	var/components_per_page = 5
+	var/magnetized = 0 //INF
 	health = 30
 	pass_flags = 0
 	anchored = FALSE
@@ -461,7 +462,7 @@
 		detail_color = D.detail_color
 		update_icon()
 //[INF]
-	else if(is_type_in_list(I, list(/obj/item/weapon/gun/energy/, /obj/item/weapon/aicard, /obj/item/device/paicard, /obj/item/device/mmi)) && opened)
+	else if(is_type_in_list(I, list(/obj/item/weapon/gun/energy/, /obj/item/weapon/grenade/, /obj/item/weapon/aicard, /obj/item/device/paicard, /obj/item/device/mmi)) && opened)
 		loading(I,user)
 //[/INF]
 	else if(istype(I, /obj/item/weapon/screwdriver))
@@ -524,7 +525,7 @@
 	return src
 
 /obj/item/device/electronic_assembly/attack_hand(mob/user)
-	if(anchored)
+	if(anchored || (magnetized && istype(src.loc, /turf/simulated/floor/))) //INF
 		attack_self(user)
 		return
 	..()

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -462,7 +462,7 @@
 		detail_color = D.detail_color
 		update_icon()
 //[INF]
-	else if(is_type_in_list(I, list(/obj/item/weapon/gun/energy/, /obj/item/weapon/grenade/, /obj/item/weapon/aicard, /obj/item/device/paicard, /obj/item/device/mmi)) && opened)
+	else if(is_type_in_list(I, list(/obj/item/weapon/gun/energy/, /obj/item/weapon/grenade/, /obj/item/weapon/aicard, /obj/item/device/paicard, /obj/item/device/mmi, /obj/item/organ/internal/posibrain/)) && opened)
 		loading(I,user)
 //[/INF]
 	else if(istype(I, /obj/item/weapon/screwdriver))

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -147,6 +147,10 @@ a creative player the means to solve many problems.  Circuits are held inside an
 	HTML += "<a href='?src=\ref[src];scan=1'>\[Copy Ref\]</a>"
 	if(assembly && removable)
 		HTML += "  |  <a href='?src=\ref[assembly];component=\ref[src];remove=1'>\[Remove\]</a>"
+	//[INF]
+	if((istype(src, /obj/item/integrated_circuit/manipulation/weapon_firing) && src.vars["installed_gun"] != null) || (istype(src, /obj/item/integrated_circuit/manipulation/ai) && src.vars["controlling"] != null) || (istype(src, /obj/item/integrated_circuit/manipulation/grenade) && src.vars["attached_grenade"] != null))
+		HTML += "  |  <a href='?src=\ref[src];iremove=1'>\[Remove item\]</a>"
+	//[/INF]
 	HTML += "<br>"
 
 	HTML += "<colgroup>"
@@ -293,6 +297,19 @@ a creative player the means to solve many problems.  Circuits are held inside an
 			to_chat(usr, "<span class='warning'>You need a screwdriver to remove components.</span>")
 		interact_with_assembly(usr)
 		. = IC_TOPIC_REFRESH
+	//[INF]
+	else if(href_list["iremove"])
+		if(istype(src,/obj/item/integrated_circuit/manipulation/weapon_firing))
+			var/obj/item/integrated_circuit/manipulation/weapon_firing/B = src
+			B.eject_gun(usr)
+		else if(istype(src,/obj/item/integrated_circuit/manipulation/ai))
+			var/obj/item/integrated_circuit/manipulation/ai/B = src
+			B.unload_ai()
+		else if(istype(src,/obj/item/integrated_circuit/manipulation/grenade))
+			var/obj/item/integrated_circuit/manipulation/grenade/B = src
+			B.detach_grenade()
+		internal_examine(usr)
+	//[/INF]
 
 	else
 		. = OnICTopic(href_list, usr)

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -60,10 +60,12 @@
 		..()
 
 /obj/item/integrated_circuit/manipulation/weapon_firing/attack_self(var/mob/user)
-	eject_gun(user) //INF
-
 //[INF]
+	eject_gun(user)
+
+
 /obj/item/integrated_circuit/manipulation/weapon_firing/proc/eject_gun(var/mob/user)
+//[/INF]
 	if(installed_gun)
 		installed_gun.dropInto(loc)
 		to_chat(user, "<span class='notice'>You slide \the [installed_gun] out of the firing mechanism.</span>")
@@ -74,7 +76,6 @@
 		push_data()
 	else
 		to_chat(user, "<span class='notice'>There's no weapon to remove from the mechanism.</span>")
-//[/INF]
 
 /obj/item/integrated_circuit/manipulation/weapon_firing/do_work(ord)
 	if(!installed_gun)

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -60,6 +60,10 @@
 		..()
 
 /obj/item/integrated_circuit/manipulation/weapon_firing/attack_self(var/mob/user)
+	eject_gun(user) //INF
+
+//[INF]
+/obj/item/integrated_circuit/manipulation/weapon_firing/proc/eject_gun(var/mob/user)
 	if(installed_gun)
 		installed_gun.dropInto(loc)
 		to_chat(user, "<span class='notice'>You slide \the [installed_gun] out of the firing mechanism.</span>")
@@ -70,6 +74,7 @@
 		push_data()
 	else
 		to_chat(user, "<span class='notice'>There's no weapon to remove from the mechanism.</span>")
+//[/INF]
 
 /obj/item/integrated_circuit/manipulation/weapon_firing/do_work(ord)
 	if(!installed_gun)
@@ -598,11 +603,15 @@
 	cooldown_per_use = 1 SECOND
 	power_draw_per_use = 20
 	var/obj/item/aicard
-	inputs = list()
+	inputs = list("Instructions" = IC_PINTYPE_STRING) //INF
 	outputs = list("AI's signature" = IC_PINTYPE_STRING, "Clicked Ref" = IC_PINTYPE_REF) //INF
 	activators = list("Upwards" = IC_PINTYPE_PULSE_OUT, "Downwards" = IC_PINTYPE_PULSE_OUT, "Left" = IC_PINTYPE_PULSE_OUT, "Right" = IC_PINTYPE_PULSE_OUT, "Push AI Name" = IC_PINTYPE_PULSE_IN,  "On click" = IC_PINTYPE_PULSE_OUT, "On middle click" = IC_PINTYPE_PULSE_OUT, "On double click" = IC_PINTYPE_PULSE_OUT, "On shift click" = IC_PINTYPE_PULSE_OUT, "On ctrl click" = IC_PINTYPE_PULSE_OUT, "On alt click" = IC_PINTYPE_PULSE_OUT) //INF
 	origin_tech = list(TECH_DATA = 4)
 	spawn_flags = IC_SPAWN_RESEARCH
+//[INF]
+	var/eol = "&lt;br&gt;"
+	var/instruction = null
+//[/INF]
 
 /obj/item/integrated_circuit/manipulation/ai/verb/open_menu()
 	set name = "Control Inputs"
@@ -641,6 +650,18 @@
 		aicard = card
 		user.visible_message("\The [user] loads \the [card] into \the [src]'s device slot")
 		to_chat(L, "<span class='notice'>### IICC FIRMWARE LOADED ###</span>")
+		//[INF]
+	var/datum/integrated_io/P = inputs[1]
+	if(isweakref(P.data))
+		var/datum/d = P.data_as_type(/datum)
+		if(d)
+			instruction = "[d]"
+	else
+		instruction = replacetext("[P.data]", eol , "<br>")
+
+	if(instruction)
+		to_chat(L, instruction)
+		//[/INF]
 		set_pin_data(IC_OUTPUT, 1, controlling.name)
 
 /obj/item/integrated_circuit/manipulation/ai/proc/unload_ai()

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -40,7 +40,8 @@
 	activators = list(
 		"create smoke" = IC_PINTYPE_PULSE_IN,
 		"on smoked" = IC_PINTYPE_PULSE_OUT,
-		"push ref" = IC_PINTYPE_PULSE_IN
+		"push ref" = IC_PINTYPE_PULSE_IN,
+		"on push ref" = IC_PINTYPE_PULSE_OUT //INF
 		)
 	spawn_flags = IC_SPAWN_RESEARCH
 	power_draw_per_use = 20
@@ -68,6 +69,7 @@
 			activate_pin(2)
 		if(3)
 			set_pin_data(IC_OUTPUT, 2, weakref(src))
+			activate_pin(4) //INF
 			push_data()
 
 /obj/item/integrated_circuit/reagent/injector
@@ -97,8 +99,8 @@
 		"inject" = IC_PINTYPE_PULSE_IN,
 		"on injected" = IC_PINTYPE_PULSE_OUT,
 		"on fail" = IC_PINTYPE_PULSE_OUT,
-		"push ref" = IC_PINTYPE_PULSE_IN
-
+		"push ref" = IC_PINTYPE_PULSE_IN,
+		"on push ref" = IC_PINTYPE_PULSE_OUT //INF
 		)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	power_draw_per_use = 15
@@ -127,6 +129,7 @@
 			inject()
 		if(4)
 			set_pin_data(IC_OUTPUT, 2, weakref(src))
+			activate_pin(5) //INF
 			push_data()
 
 /obj/item/integrated_circuit/reagent/injector/proc/target_nearby(var/weakref/target)
@@ -306,13 +309,14 @@
 		"volume used" = IC_PINTYPE_NUMBER,
 		"self reference" = IC_PINTYPE_REF
 		)
-	activators = list("push ref" = IC_PINTYPE_PULSE_IN)
+	activators = list("push ref" = IC_PINTYPE_PULSE_IN, "on push ref" = IC_PINTYPE_PULSE_OUT) //INF
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 
 
 /obj/item/integrated_circuit/reagent/storage/do_work()
 	set_pin_data(IC_OUTPUT, 2, weakref(src))
+	activate_pin(2) //INF
 	push_data()
 
 /obj/item/integrated_circuit/reagent/storage/on_reagent_change(changetype)
@@ -354,7 +358,8 @@
 		"grind" = IC_PINTYPE_PULSE_IN,
 		"on grind" = IC_PINTYPE_PULSE_OUT,
 		"on fail" = IC_PINTYPE_PULSE_OUT,
-		"push ref" = IC_PINTYPE_PULSE_IN
+		"push ref" = IC_PINTYPE_PULSE_IN,
+		"on push ref" = IC_PINTYPE_PULSE_OUT //INF
 		)
 	volume = 100
 	power_draw_per_use = 150
@@ -368,6 +373,7 @@
 			grind()
 		if(4)
 			set_pin_data(IC_OUTPUT, 2, weakref(src))
+			activate_pin(5) //INF
 			push_data()
 
 /obj/item/integrated_circuit/reagent/storage/grinder/proc/grind()
@@ -382,7 +388,7 @@
 	if(!I.reagents || !I.reagents.total_volume)
 		activate_pin(3)
 		return FALSE
-	
+
 	I.reagents.trans_to(src,I.reagents.total_volume)
 	if(!I.reagents.total_volume)
 		qdel(I)
@@ -406,7 +412,8 @@
 		)
 	activators = list(
 		"scan" = IC_PINTYPE_PULSE_IN,
-		"push ref" = IC_PINTYPE_PULSE_IN
+		"push ref" = IC_PINTYPE_PULSE_IN,
+		"on push ref" = IC_PINTYPE_PULSE_OUT //INF
 		)
 	spawn_flags = IC_SPAWN_RESEARCH
 
@@ -420,6 +427,7 @@
 			push_data()
 		if(2)
 			set_pin_data(IC_OUTPUT, 2, weakref(src))
+			activate_pin(3) //INF
 			push_data()
 
 /obj/item/integrated_circuit/reagent/filter
@@ -540,7 +548,8 @@
 	activators = list(
 		"toggle" = IC_PINTYPE_PULSE_IN,
 		"on toggle" = IC_PINTYPE_PULSE_OUT,
-		"push ref" = IC_PINTYPE_PULSE_IN
+		"push ref" = IC_PINTYPE_PULSE_IN,
+		"on push ref" = IC_PINTYPE_PULSE_OUT //INF
 	)
 
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
@@ -584,6 +593,7 @@
 				QUEUE_TEMPERATURE_ATOMS(src)
 		if(3)
 			set_pin_data(IC_OUTPUT, 4, weakref(src))
+			activate_pin(4) //INF
 			push_data()
 
 /obj/item/integrated_circuit/reagent/temp/on_reagent_change()
@@ -608,7 +618,7 @@
 		if(!check_power())
 			power_fail()
 			return ..()
-	
+
 		set_pin_data(IC_OUTPUT, 2, temperature - T0C)
 		push_data()
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -238,6 +238,13 @@
 	if(world.time <= last_special)
 		return
 
+	//[INF]
+	var/obj/item/integrated_circuit/manipulation/ai/A = src.loc
+	if(istype(A))
+		A.unload_ai()
+		src.visible_message("[src] ejects from [A].")
+	//[/INF]
+
 	close_up()
 	update_verbs() //inf
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -214,7 +214,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			return TRUE
 
 	// Otherwise we can make a start on surgery!
-	else if(istype(M) && !QDELETED(M) && user.a_intent != I_HURT && user.get_active_hand() == src)
+	else if(istype(M) && !QDELETED(M) && user.a_intent != I_HURT && (user.get_active_hand() == src || istype(src.loc, /mob/living/silicon/) && istype(user.get_active_hand(), /obj/item/weapon/gripper/))) //INF
 		// Double-check this in case it changed between initial check and now.
 		if(zone in M.surgeries_in_progress)
 			to_chat(user, SPAN_WARNING("You can't operate on this area while surgery is already in progress."))

--- a/infinity/code/modules/integrated_electronics/core/assemblies.dm
+++ b/infinity/code/modules/integrated_electronics/core/assemblies.dm
@@ -6,6 +6,11 @@
 			if(!P.installed_gun)
 				icomponents+=P.displayed_name
 				ircomponents+=P
+	else if(istype(I, /obj/item/weapon/grenade/))
+		for (var/obj/item/integrated_circuit/manipulation/grenade/P in assembly_components)
+			if(!P.attached_grenade)
+				icomponents+=P.displayed_name
+				ircomponents+=P
 	else
 		var/obj/item/card = I
 		var/mob/living/L = locate(/mob/living) in card.contents

--- a/infinity/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/infinity/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -23,3 +23,51 @@
 				C.activate_pin(6)
 		else
 			C.activate_pin(8)
+
+/obj/item/integrated_circuit/manipulation/magnetizer
+	name = "floor magnet"
+	desc = "Magnetize your assembly to the floor so no one can pick it up while it is active. Assembly can still be moved."
+
+	outputs = list(
+		"enabled" = IC_PINTYPE_BOOLEAN
+	)
+	activators = list(
+		"toggle" = IC_PINTYPE_PULSE_IN,
+		"on toggle" = IC_PINTYPE_PULSE_OUT
+	)
+
+	complexity = 16
+	cooldown_per_use = 5 SECOND
+	power_draw_per_use = 50
+	power_draw_idle = 0
+	spawn_flags = IC_SPAWN_DEFAULT
+	origin_tech = list(TECH_ENGINEERING = 4, TECH_MAGNETS = 4)
+
+/obj/item/integrated_circuit/manipulation/magnetizer/do_work(ord)
+	if(!isturf(assembly.loc))
+		return
+
+	if(ord == 1 && src.loc == assembly)
+		assembly.magnetized = !assembly.magnetized
+		power_draw_idle = assembly.magnetized ? 50 : 0
+
+		visible_message(
+			assembly.magnetized ? \
+			"<span class='notice'>\The [get_object()] sticks to the floor!</span>" \
+			: \
+			"<span class='notice'>\The [get_object()] deactivates its magnets</span>"
+		)
+
+		set_pin_data(IC_OUTPUT, 1, assembly.magnetized)
+		push_data()
+		activate_pin(2)
+
+/obj/item/integrated_circuit/manipulation/magnetizer/power_fail()
+	assembly.magnetized = 0
+	power_draw_idle = 0
+	set_pin_data(IC_OUTPUT, 1, assembly.magnetized)
+
+/obj/item/integrated_circuit/manipulation/magnetizer/disconnect_all()
+	assembly.magnetized = 0
+	power_draw_idle = 0
+	set_pin_data(IC_OUTPUT, 1, assembly.magnetized)


### PR DESCRIPTION
- пИИ при нажатии collapse chassis нормально отсоединяется от Intelligence control платы.
- Добавлен входящий параметр Instruction для intelligence control module с поддержкой тега br, сюда можно записать, к примеру, инструкцию по управлению, которая будет отображаться для пИИ/ММИ при установке в плату.
- Добавлена возможность вставлять гранату в соответствующую плату через клик по открытому корпусу.
- Добавлена ссылка [Remove Item] в интерфейсе для плат grenade primer, weapon firing mechanism, intelligence control module для быстрого изъятия из них вещей без пересборки. (Появляется только если в плате есть предмет на изъятие - https://prnt.sc/s18zq3).
- Добавлен активатор on push ref для большинства плат связанных с реагентами для упрощения интеракции с ними.
- Добавлена плата floor magnet в раздел manipulation, в активном состоянии потребляет энергию и не дает взять устройство с пола. (Все ещё может перемещаться самостоятельно и через pull, работает только с полом типа /turf/simulated/floor/, на тайле с космосом, к примеру, можно взять даже в активном состоянии).