### PR TITLE
Увеличиваем шанс попадания по органам от лазеров

### DIFF
--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -142,7 +142,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	if(damage_flags & DAM_SHARP)
 		organ_damage_threshold *= 0.5
 	if(laser)
-		organ_damage_threshold *= 2
+		organ_damage_threshold *= 1 //INF, WAS 2
 
 	if(!(cur_damage + damage_amt >= max_damage) && !(damage_amt >= organ_damage_threshold))
 		return FALSE


### PR DESCRIPTION
По стандарту было значение два из-за чего процентный шанс попасть по органам падал. К примеру было 5*(дамаг пульсача=30)/(0.5*2) = 15% шанс попасть и того 100/15% = округляем до 7, из 7 выстрелов только один проходил по органу из-за чего приходилось примерно тратить 13 выстрелов только для крита. Теперь же 5*30/(0.5*1) = 30%, 100/30% = 3,3 округляем до 3. Теперь из трёх выстрелов будет попадать один. Данное действие для всех лазеров