### PR TITLE
Ограничение профессий бустеров

### DIFF
--- a/maps/sierra/job/jobs.dm
+++ b/maps/sierra/job/jobs.dm
@@ -26,6 +26,10 @@
 									/datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer,/datum/job/qm,\
 									/datum/job/senior_engineer, /datum/job/senior_doctor, /datum/job/psychiatrist,\
 									/*/datum/job/stowaway,*/ /datum/job/senior_scientist, /datum/job/security_assistant),
+		/datum/species/human/booster= list(HUMAN_ONLY_JOBS, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer,\
+									/datum/job/iaa, /datum/job/adjutant, /datum/job/exploration_leader, /datum/job/senior_engineer,\
+									/datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/security_assistant,
+									/datum/job/qm, /datum/job/senior_scientist)
 	)
 #undef HUMAN_ONLY_JOBS
 


### PR DESCRIPTION
Это самая первая версия.
Текущая ограничивает следующие:
Главы, АВД, КМ, ЛЭ, старший инженер, старший ученый, вся охрана.
Забавности:
<details>

Резоми:
<details>

![image](https://user-images.githubusercontent.com/19491666/81474585-bae6e100-9230-11ea-92b1-5dc6944298e2.png)
</details>

Бустеры:
<details>

![image](https://user-images.githubusercontent.com/19491666/81474592-c2a68580-9230-11ea-95e9-842b45375674.png)

</details>
</details>