### PR TITLE
Решением главы ксенокома. Снижение возможности автоспавна ахсентов до нуля. Исправление текста ахсентов в начале игры.

### DIFF
--- a/code/modules/ascent/ascent_rigs.dm
+++ b/code/modules/ascent/ascent_rigs.dm
@@ -7,8 +7,8 @@
 	suit_type = "support exosuit"
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
-		bullet = ARMOR_BALLISTIC_RESISTANT, //INF WAS 1.1 * ARMOR_BALLISTIC_RESISTANT
-		laser = ARMOR_LASER_MAJOR, //INF WAS 1.1 * ARMOR_LASER_RIFLES
+		bullet = 1.1 * ARMOR_BALLISTIC_RESISTANT,
+		laser = 1.1 * ARMOR_LASER_RIFLES,
 		energy = ARMOR_ENERGY_RESISTANT,
 		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_SHIELDED,

--- a/code/modules/ascent/ascent_rigs.dm
+++ b/code/modules/ascent/ascent_rigs.dm
@@ -7,8 +7,8 @@
 	suit_type = "support exosuit"
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
-		bullet = 1.1 * ARMOR_BALLISTIC_RESISTANT,
-		laser = 1.1 * ARMOR_LASER_RIFLES,
+		bullet = ARMOR_BALLISTIC_RESISTANT, //INF WAS 1.1 * ARMOR_BALLISTIC_RESISTANT
+		laser = ARMOR_LASER_MAJOR, //INF WAS 1.1 * ARMOR_LASER_RIFLES
 		energy = ARMOR_ENERGY_RESISTANT,
 		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_SHIELDED,

--- a/maps/away/ascent/ascent.dm
+++ b/maps/away/ascent/ascent.dm
@@ -10,7 +10,7 @@
 	id = "awaysite_ascent_seedship"
 	description = "A small Ascent colony ship."
 	suffixes = list("ascent/ascent-1.dmm")
-	cost = 1000 //INF, WAS 1
+	cost = 2 //INF, WAS 0.5
 	spawn_weight = 50 //INF, HABITABLE SHIPS SPAWN
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/ascent,

--- a/maps/away/ascent/ascent_jobs.dm
+++ b/maps/away/ascent/ascent_jobs.dm
@@ -81,7 +81,7 @@
 	title = "Ascent Gyne"
 	total_positions = 1
 	supervisors = "nobody but yourself"
-	info = "You are the Gyne of an independent Ascent vessel. Your hunting has brought you to this remote sector full of crawling primitives. Impose your will, found a new nest, and bring prosperity to your lineage."
+	info = "Вы гиина, одного из независимых судов восхождения. Ваша колонизация, привела вас в этот отдаленный сектор, полный примитивов. Создайте новое гнездо, и прославьте свою родословную."
 	outfit_type = /decl/hierarchy/outfit/job/ascent
 	blacklisted_species = null
 	whitelisted_species = null
@@ -158,7 +158,7 @@
 					SKILL_HAULING = SKILL_ADEPT,
 					SKILL_COMBAT = SKILL_ADEPT,
 					SKILL_WEAPONS = SKILL_ADEPT,
-					SKILL_MEDICAL = SKILL_BASIC)	
+					SKILL_MEDICAL = SKILL_BASIC)
 
 /datum/job/submap/ascent/drone
 	title = "Ascent Drone"

--- a/maps/away_inf/ascent/ascent.dm
+++ b/maps/away_inf/ascent/ascent.dm
@@ -11,7 +11,7 @@
 	description = "A small Ascent colony ship. Looks like it was damaged."
 	prefix = "maps/away_inf/"
 	suffixes = list("ascent/ascent-1.dmm")
-	cost = 2
+	cost = 1000 //INF WAS 2
 	spawn_weight = 50 //HABITABLE SHIPS SPAWN
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/ascent_inf,


### PR DESCRIPTION
* Спавн аскентов нужно уменьшить до 1-2 раз в неделю.  - Теперь только админы смогу спавнить их.

* Аскентам нужно дать нормальный не сломанный корабль.  - Думаю админы поймут название, поврежденный колониальный корабль восхождения и обычный, и что спавнить.

* Аскентов следует лишить ригов, или уменьшить им броню для устранения их  
 неубиваемости.  - Убрал множитель у рига Алатов и уменьшил показатель брони от лазеров.

* Нужно пофиксить инфу в начале игры  у аскентов, вопреки лору и назначению корабля в самом начале в чате показывается инфа, что их в систему привела ОХОТА, а не колонизационная мисси, следовательно нужно исправить на колонизацию.  - Исправил текст.