### PR TITLE
попытка пофиксить релейшны

### DIFF
--- a/code/modules/client/preference_setup/matchmaking/matchmaking.dm
+++ b/code/modules/client/preference_setup/matchmaking/matchmaking.dm
@@ -14,13 +14,18 @@ var/global/datum/matchmaker/matchmaker = new()
 		var/datum/relation/R = T
 		relation_types[initial(R.name)] = T
 
-/datum/matchmaker/proc/do_matchmaking()
+/datum/matchmaker/proc/do_matchmaking(var/mob/char) //INF WAS /datum/matchmaker/proc/do_matchmaking()
 	var/list/to_warn = list()
 	for(var/datum/relation/R in relations)
 		if(!R.other)
 			R.find_match()
 		if(R.other && !R.finalized)
 			to_warn |= R.holder.current
+//[INF]
+	if(char)
+		to_chat(char,"<span class='warning'>Вы установили механические отношения с кем-то. Нажмите \"<a href='byond://?src=\ref[M];show_relations=1'>Посмотреть отношения</a>\" чтобы просмотреть и утвердить их.</span>")
+		return
+//[/INF]
 	for(var/mob/M in to_warn)
 		to_chat(M,"<span class='warning'>Вы установили механические отношения с кем-то. Нажмите \"<a href='byond://?src=\ref[M];show_relations=1'>Посмотреть отношения</a>\" чтобы просмотреть и утвердить их.</span>")
 

--- a/code/modules/client/preference_setup/matchmaking/matchmaking.dm
+++ b/code/modules/client/preference_setup/matchmaking/matchmaking.dm
@@ -23,7 +23,7 @@ var/global/datum/matchmaker/matchmaker = new()
 			to_warn |= R.holder.current
 //[INF]
 	if(char)
-		to_chat(char,"<span class='warning'>Вы установили механические отношения с кем-то. Нажмите \"<a href='byond://?src=\ref[M];show_relations=1'>Посмотреть отношения</a>\" чтобы просмотреть и утвердить их.</span>")
+		to_chat(char,"<span class='warning'>Вы установили механические отношения с кем-то. Нажмите \"<a href='byond://?src=\ref[char];show_relations=1'>Посмотреть отношения</a>\" чтобы просмотреть и утвердить их.</span>")
 		return
 //[/INF]
 	for(var/mob/M in to_warn)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -381,7 +381,7 @@
 			AnnounceArrival(character, job, spawnpoint.msg)
 		else
 			AnnounceCyborg(character, job, spawnpoint.msg)
-		matchmaker.do_matchmaking()
+		matchmaker.do_matchmaking(character) //INF WAS matchmaker.do_matchmaking()
 	log_and_message_admins("has joined the round as [character.mind.assigned_role].", character)
 
 	if(character.needs_wheelchair())


### PR DESCRIPTION
nuff said, насколько я понял сообщение постоянно повторялось из-за лэйтжойна. а он вызывает прок 
do_matchmaking()
теперь лэйтжойн передает аргумент персонажа в него: 
matchmaker.do_matchmaking(character), и он выведет сообщение только тому кто зашел. скорее всего. 