### PR TITLE
Фикс баклинга резоми

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -69,7 +69,7 @@
 			animate(M, pixel_x = M.default_pixel_x, pixel_y = M.default_pixel_y, pixel_z = M.default_pixel_z, 4, 1, LINEAR_EASING)
 
 /obj/proc/user_buckle_mob(mob/living/M, mob/user)
-	if(!user.Adjacent(M) || istype(user, /mob/living/silicon/pai) || (M != user && user.incapacitated()) || user.mob_size < M.mob_size) //INF, was if(!user.Adjacent(M) || istype(user, /mob/living/silicon/pai) || (M != user && user.incapacitated()))
+	if(!user.Adjacent(M) || istype(user, /mob/living/silicon/pai) || (M != user && user.incapacitated()) || user.mob_size <= MOB_TINY) //INF, was if(!user.Adjacent(M) || istype(user, /mob/living/silicon/pai) || (M != user && user.incapacitated()))
 		return 0
 	if(M == buckled_mob)
 		return 0


### PR DESCRIPTION
Резоми не могут пристегивать к стульям; данный pull-request изменяет это, не позволяя пристегивать мобов тем, чей mob_size <= MOB_TINY