### PR TITLE
фикс?? чтения флавора из гостоты

### DIFF
--- a/code/modules/nano/interaction/base.dm
+++ b/code/modules/nano/interaction/base.dm
@@ -8,6 +8,11 @@
 	var/datum/src_object = nano_host()
 	return state.can_use_topic(src_object, user)
 
+/mob/CanUseTopic(mob/user, datum/topic_state/state, href_list)
+	if(href_list["flavor_more"])
+		return STATUS_INTERACTIVE
+	return ..()
+
 /datum/proc/CanUseTopicPhysical(mob/user)
 	return CanUseTopic(user, GLOB.physical_state)
 


### PR DESCRIPTION
честно украденная технология запада, адаптированная на русский лад, позволяет снова видеть флаворы из гостоты
одобрено антиерпшерами

это также распространяется на записи и, скорее всего, на оос нотесы

![ilovesemen](https://user-images.githubusercontent.com/47539404/102058749-084bb200-3e01-11eb-8c4a-b13dea9b92f2.png)