### PR TITLE
Добавляем Low Workboots в лодаут

### DIFF
--- a/maps/sierra/loadout/loadout_shoes.dm
+++ b/maps/sierra/loadout/loadout_shoes.dm
@@ -10,3 +10,7 @@
 /datum/gear/shoes/dress
 	display_name = "dress shoes"
 	path = /obj/item/clothing/shoes/dress
+	
+/datum/gear/shoes/lowworkboots
+	display_name = "low workboots"
+	path = /obj/item/clothing/shoes/workboots/alt


### PR DESCRIPTION
Теперь в лодауте можно взять лоу воркбуты. Те самые воркбуты, но сексуальнее. Их как минимум три человека просило добавить, но за несколько месяцев это так и не сделали.

Ещё подробнее?
В лодауте появились **low workboots** в разделе **Shoes and Footwear**. Стоят они, к слову, всего один поинт лодаута.

![image](https://user-images.githubusercontent.com/22749671/104574375-fca11480-5666-11eb-8eb1-6abfcfd27c2b.png)

![image](https://user-images.githubusercontent.com/22749671/104574445-13e00200-5667-11eb-876b-4c9b2779f78c.png)

