### PR TITLE
Фикс мутаций ксеноботаники

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -732,7 +732,7 @@
 		if(istype(user)) to_chat(user, "You [harvest_sample ? "take a sample" : "harvest"] from the [display_name].")
 		//This may be a new line. Update the global if it is.
 		if(name == "new line" || !(name in SSplants.seeds))
-			uid = SSplants.seeds.len + 1
+			uid = sequential_id(/datum/seed/) // inf
 			name = "[uid]"
 			SSplants.seeds[name] = src
 


### PR DESCRIPTION
[За помощь спасибо Skonoplich-y]

Фикс генерации названий мутировавших растений. Изначально названия для мутантов хранились в контроллере SSPlants который задавал имя посредством считывания списка всех семян как их сумму + 1, то же самое делалось и для процедурно-генерируемых. При создании семячки получалось две копии имени, и после того как плод запихивали в сид экстрактор он выдавал семечку процедурно-генерируемого (изначального семени имя которого первым хранилось в списке). Ошибка вышла из-за невнимательности кодеров бея12. Заметить сложно, за что спасибо выше сказанному человеку.
