### PR TITLE
Убираем из спавна Vox Base

### DIFF
--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -9,7 +9,7 @@
 	description = "Vox ship and base."
 	suffixes = list("voxship/voxship-1.dmm")
 	spawn_weight = 50 //INF, HABITABLE SHIPS SPAWN
-	cost = 2 //INF, WAS 0.5
+	cost = 1000 //INF, WAS 0.5
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_shuttle)
 	area_usage_test_exempted_root_areas = list(/area/voxship)
 	ban_ruins = list(/datum/map_template/ruin/away_site/scavship)


### PR DESCRIPTION
Эта авейкарта была удалена с актуального бэя. В наших же реалиях своей огромной стоимостью она буквально выжигает другие авейки, cost у которых обычно варьируется от 0,5 до 1. Думаю после этого должно быть понятно, в какую пустыню превращается овермап после появления этого недоразумения. 
Я понимаю, что удаляются авейкарты не так, но мои попытки вырезать его полностью привели только к огромному числу ошибок. Пример подобного "фикса" увидел в нашем коде, как бы, почему нет.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

## Changelog
:cl:
bugfix: Убрал спавн VoxBase из авеек
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
