### PR TITLE
Adherent job

### DIFF
--- a/maps/sierra/job/jobs.dm
+++ b/maps/sierra/job/jobs.dm
@@ -1,8 +1,8 @@
 /datum/map/sierra
 	species_to_job_whitelist = list(
 		/datum/species/adherent = list(/datum/job/ai, /datum/job/cyborg, /datum/job/assistant, /datum/job/janitor,\
-									   /datum/job/chef, /datum/job/cargo_tech, /datum/job/scientist,\
-									   /datum/job/doctor, /datum/job/engineer, /datum/job/mining,\
+									   /datum/job/chef, /datum/job/cargo_tech, /datum/job/scientist_assistant,\
+									   /datum/job/doctor_trainee, /datum/job/engineer, /datum/job/mining,\
 									   /datum/job/roboticist, /datum/job/chemist, /datum/job/bartender, /datum/job/explorer_engineer),
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant,\
 									 /datum/job/chemist, /datum/job/roboticist, /datum/job/cargo_assistant, /datum/job/chef,\

--- a/maps/sierra/job/jobs.dm
+++ b/maps/sierra/job/jobs.dm
@@ -1,8 +1,8 @@
 /datum/map/sierra
 	species_to_job_whitelist = list(
-		/datum/species/adherent = list(/datum/job/ai, /datum/job/cyborg, /datum/job/assistant, /datum/job/janitor,\
+		/datum/species/adherent = list(/datum/job/ai, /datum/job/cyborg, /datum/job/assistant, /datum/job/janitor, /datum/job/engineer_trainee,\
 									   /datum/job/chef, /datum/job/cargo_tech, /datum/job/scientist_assistant,\
-									   /datum/job/doctor_trainee, /datum/job/engineer, /datum/job/mining,\
+									   /datum/job/doctor_trainee, /datum/job/engineer, /datum/job/mining, /datum/job/cargo_assistant,\
 									   /datum/job/roboticist, /datum/job/chemist, /datum/job/bartender, /datum/job/explorer_engineer),
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant,\
 									 /datum/job/chemist, /datum/job/roboticist, /datum/job/cargo_assistant, /datum/job/chef,\

--- a/maps/sierra/job/jobs.dm
+++ b/maps/sierra/job/jobs.dm
@@ -3,8 +3,7 @@
 		/datum/species/adherent = list(/datum/job/ai, /datum/job/cyborg, /datum/job/assistant, /datum/job/janitor,\
 									   /datum/job/chef, /datum/job/cargo_tech, /datum/job/scientist,\
 									   /datum/job/doctor, /datum/job/engineer, /datum/job/mining,\
-									   /datum/job/roboticist, /datum/job/chemist, /datum/job/bartender,\
-									   /datum/job/explorer_medic, /datum/job/explorer_engineer),
+									   /datum/job/roboticist, /datum/job/chemist, /datum/job/bartender, /datum/job/explorer_engineer),
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant,\
 									 /datum/job/chemist, /datum/job/roboticist, /datum/job/cargo_assistant, /datum/job/chef,\
 									 /datum/job/engineer_trainee, /datum/job/doctor_trainee, /datum/job/bartender),

--- a/maps/sierra/job/jobs.dm
+++ b/maps/sierra/job/jobs.dm
@@ -1,9 +1,10 @@
 /datum/map/sierra
 	species_to_job_whitelist = list(
 		/datum/species/adherent = list(/datum/job/ai, /datum/job/cyborg, /datum/job/assistant, /datum/job/janitor,\
-									   /datum/job/chef, /datum/job/cargo_assistant, /datum/job/scientist_assistant,\
-									   /datum/job/doctor_trainee, /datum/job/engineer_trainee, /datum/job/engineer, /datum/job/mining,
-									   /datum/job/roboticist, /datum/job/chemist, /datum/job/bartender),
+									   /datum/job/chef, /datum/job/cargo_tech, /datum/job/scientist,\
+									   /datum/job/doctor, /datum/job/engineer, /datum/job/mining,\
+									   /datum/job/roboticist, /datum/job/chemist, /datum/job/bartender,\
+									   /datum/job/explorer_medic, /datum/job/explorer_engineer),
 		/datum/species/nabber = list(/datum/job/ai, /datum/job/cyborg, /datum/job/janitor, /datum/job/scientist_assistant,\
 									 /datum/job/chemist, /datum/job/roboticist, /datum/job/cargo_assistant, /datum/job/chef,\
 									 /datum/job/engineer_trainee, /datum/job/doctor_trainee, /datum/job/bartender),


### PR DESCRIPTION
По какой-то причине синтетические-кристаллические единицы могли занимать только должности ассистентов и стажеров, за исключением инженерного отдела, что банально смешно.
Так же по какой-то причине работы инженера и медика ЭК были закрыты для адхерантов.
Такое мнение взялось не с пустого места, на Факеле часовые имели доступ ко всем этим отделам и профессиям и даже пилоту, к сожалению у нас пилот занимается командованием и адхеранту подобную процессию не доверить.
P S Это старое описание ПРа, по итогам были добавлены профы карготехника и филд инженера, вот и весь ПР
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

## Changelog
:cl:
balance: Доступные адхерантам работы изменены. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
