### PR TITLE
Разделение стоимости авейки на очки карты и очки игроков

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3720,6 +3720,7 @@
 #include "infinity\code\modules\telesci\telesci_computer.dm"
 #include "infinity\code\modules\weapon_construction\_weapon_construction_setup.dm"
 #include "infinity\code\modules\webhooks\webhook_ban_message.dm"
+#include "infinity\code\modules\webhooks\webhook_nearend.dm"
 #include "infinity\code\modules\webhooks\webhook_roundend.dm"
 #include "infinity\code\modules\webhooks\webhook_roundstart.dm"
 #include "infinity\code\modules\webhooks\webhook_runtimes.dm"

--- a/code/__defines/webhooks.dm
+++ b/code/__defines/webhooks.dm
@@ -5,8 +5,9 @@
 #define WEBHOOK_CUSTOM_EVENT      "webhook_custom_event"
 
 //[INF]	Maybe move this into inf folder?
-#define WEBHOOK_SERVER_UPDATE     "webhook_server_update"
-#define WEBHOOK_SERVER_START      "webhook_server_start"
+#define WEBHOOK_SERVER_UPDATE     "webhook_server_update"       // semi-auto server updates
+#define WEBHOOK_SERVER_START      "webhook_server_start"        // server booted, collecting players in lobby
+#define WEBHOOK_NEAR_END          "webhook_nearend"             // slaps away waiters when round end can not be canceled
 #define WEBHOOK_SEND_BAN          "webhook_send_ban"			// ban announcements
 #define WEBHOOK_SEND_RUNTIME      "webhook_send_runtime"		// runtimes
 #define WEBHOOK_XENO_WHITELIST	  "webhook_xeno_whitelist"		// xenoWL changes

--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -59,7 +59,7 @@
 		. = B.qdels - A.qdels
 
 /proc/cmp_ruincost_priority(datum/map_template/ruin/A, datum/map_template/ruin/B)
-	return initial(A.cost) - initial(B.cost)
+	return initial(A.spawn_cost) - initial(B.spawn_cost)
 
 /proc/cmp_timer(datum/timedevent/a, datum/timedevent/b)
 	return a.timeToRun - b.timeToRun

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -21,7 +21,7 @@ SUBSYSTEM_DEF(ticker)
 	var/end_game_state = END_GAME_NOT_OVER
 	var/delay_end = 0               //Can be set true to postpone restart.
 	var/delay_notified = 0          //Spam prevention.
-	var/restart_timeout = 1 MINUTE
+	var/restart_timeout = 2 MINUTES
 
 	var/scheduled_map_change = 0
 	var/force_ending = 0            //Overriding this variable will force game end. Can be used for build update or adminbuse.

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -21,7 +21,7 @@ SUBSYSTEM_DEF(ticker)
 	var/end_game_state = END_GAME_NOT_OVER
 	var/delay_end = 0               //Can be set true to postpone restart.
 	var/delay_notified = 0          //Spam prevention.
-	var/restart_timeout = 2 MINUTES
+	var/restart_timeout = 1.5 MINUTES
 
 	var/scheduled_map_change = 0
 	var/force_ending = 0            //Overriding this variable will force game end. Can be used for build update or adminbuse.

--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -5,7 +5,9 @@
 	How is there a wooden container filled with 18th century coinage in the middle of a lavawracked hellscape? \
 	It is clearly a mystery."
 
-	var/cost = null //negative numbers will always be placed, with lower (negative) numbers being placed first; positive and 0 numbers will be placed randomly
+	var/spawn_weight = 1
+	var/spawn_cost = 0
+	var/player_cost = 0
 
 	var/prefix = null
 	var/suffixes = null

--- a/code/modules/maps/ruins.dm
+++ b/code/modules/maps/ruins.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 		var/datum/map_template/ruin/ruin = null
 		if(ruins && ruins.len)
 			ruin = pick(ruins)
-			if(ruin.cost > budget)
+			if(ruin.spawn_cost > budget)
 				ruins -= ruin
 				continue //Too expensive, get rid of it and try again
 		else
@@ -60,8 +60,8 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 
 			load_ruin(T, ruin)
 			spawned_ruins += ruin
-			if(ruin.cost >= 0)
-				budget -= ruin.cost
+			if(ruin.spawn_cost >= 0)
+				budget -= ruin.spawn_cost
 			if(!(ruin.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
 				for(var/other_ruin_datum in ruins)
 					var/datum/map_template/ruin/other_ruin = other_ruin_datum

--- a/config/example/torch_config.txt
+++ b/config/example/torch_config.txt
@@ -19,6 +19,9 @@
 ## The number of away sites to pick for the overmap. Default 3
 #AWAY_SITE_BUDGET 3
 
+## The number of players subtracted from the player budget for away sites by the main map. Default 12
+#MIN_OFFMAP_PLAYERS 12
+
 ## The names of various entities to use for reports, listing, etc.
 #STATION_NAME Sev Torch
 #STATION_SHORT Torch

--- a/infinity/code/controllers/evacuation/evacuation_pods.dm
+++ b/infinity/code/controllers/evacuation/evacuation_pods.dm
@@ -32,9 +32,9 @@
 
 /datum/evacuation_controller/starship/fast/launch_evacuation()
 	if(emergency_evacuation)
-		SSwebhooks.send(WEBHOOK_NEAR_END, list("reason" = "Получен аварийный сигнал с борта **[GLOB.using_map.name]**! Это эвакуация?"))	// INF
+		SSwebhooks.send(WEBHOOK_NEAR_END, list("reason" = "Получен аварийный сигнал с борта **[GLOB.using_map.full_name]**! Это эвакуация?"))
 	else
-		SSwebhooks.send(WEBHOOK_NEAR_END, list("reason" = "Потерян контакт с **[GLOB.using_map.name]**. К счастью, это всего лишь на время БлюСпейс прыжка."))	// INF
+		SSwebhooks.send(WEBHOOK_NEAR_END, list("reason" = "Потерян контакт с **[GLOB.using_map.full_name]**. К счастью, это всего лишь на время БлюСпейс прыжка."))
 	. = ..()
 
 /datum/evacuation_controller/starship/fast/cancel_evacuation()

--- a/infinity/code/controllers/evacuation/evacuation_pods.dm
+++ b/infinity/code/controllers/evacuation/evacuation_pods.dm
@@ -30,6 +30,13 @@
 		EVAC_OPT_CANCEL_BLUESPACE_JUMP = new /datum/evacuation_option/cancel_bluespace_jump()
 	)
 
+/datum/evacuation_controller/starship/fast/launch_evacuation()
+	if(emergency_evacuation)
+		SSwebhooks.send(WEBHOOK_NEAR_END, list("reason" = "Получен аварийный сигнал с борта **[GLOB.using_map.name]**! Это эвакуация?"))	// INF
+	else
+		SSwebhooks.send(WEBHOOK_NEAR_END, list("reason" = "Потерян контакт с **[GLOB.using_map.name]**. К счастью, это всего лишь на время БлюСпейс прыжка."))	// INF
+	. = ..()
+
 /datum/evacuation_controller/starship/fast/cancel_evacuation()
 	var/emerg = emergency_evacuation
 	. = ..()

--- a/infinity/code/modules/webhooks/webhook_nearend.dm
+++ b/infinity/code/modules/webhooks/webhook_nearend.dm
@@ -2,17 +2,17 @@
 	id = WEBHOOK_NEAR_END
 
 // Наличие даты означает, что раунд неминуемо закончится. И нам надо послать другое сообщение. Да-да =( 
-/decl/webhook/server_start/get_message(var/list/data)
+/decl/webhook/near_end/get_message(var/list/data)
 	. = ..()
 	if(!data.len)
-        .["content"] = "Здесь должно было быть сообщение о *неминуемом* конце раунда, но кто то вызвал вебхук вручную."
-        return
+		.["content"] = "Здесь должно было быть сообщение о *неминуемом* конце раунда, но кто то вызвал вебхук вручную."
+		return
 	var/loretext = data["reason"]
 	if(!loretext || loretext == "")
 		loretext = "Телеметрия нестабильна! Данные были повреждены!"
 	.["embeds"] = list(list(
-		"title" = "**Конец раунда неминуем! *Авейтеры* собирайтесь!**"
-		"description" = loretext
+		"title" = "**Конец раунда неминуем! *Авейтеры* собирайтесь!**",
+		"description" = loretext,
 		"color" = COLOR_WEBHOOK_XENO
 	))
 

--- a/infinity/code/modules/webhooks/webhook_nearend.dm
+++ b/infinity/code/modules/webhooks/webhook_nearend.dm
@@ -1,0 +1,18 @@
+/decl/webhook/near_end
+	id = WEBHOOK_NEAR_END
+
+// Наличие даты означает, что раунд неминуемо закончится. И нам надо послать другое сообщение. Да-да =( 
+/decl/webhook/server_start/get_message(var/list/data)
+	. = ..()
+	if(!data.len)
+        .["content"] = "Здесь должно было быть сообщение о *неминуемом* конце раунда, но кто то вызвал вебхук вручную."
+        return
+	var/loretext = data["reason"]
+	if(!loretext || loretext == "")
+		loretext = "Телеметрия нестабильна! Данные были повреждены!"
+	.["embeds"] = list(list(
+		"title" = "**Конец раунда неминуем! *Авейтеры* собирайтесь!**"
+		"description" = loretext
+		"color" = COLOR_WEBHOOK_XENO
+	))
+

--- a/infinity/code/modules/webhooks/webhook_nearend.dm
+++ b/infinity/code/modules/webhooks/webhook_nearend.dm
@@ -11,7 +11,7 @@
 	if(!loretext || loretext == "")
 		loretext = "Телеметрия нестабильна! Данные были повреждены!"
 	.["embeds"] = list(list(
-		"title" = "**Конец раунда неминуем! *Авейтеры* собирайтесь!**",
+		"title" = "**Конец раунда неминуем! *Авейтеры собирайтесь!***",
 		"description" = loretext,
 		"color" = COLOR_WEBHOOK_XENO
 	))

--- a/maps/away/ascent/ascent.dm
+++ b/maps/away/ascent/ascent.dm
@@ -10,7 +10,8 @@
 	id = "awaysite_ascent_seedship"
 	description = "A small Ascent colony ship."
 	suffixes = list("ascent/ascent-1.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
+	player_cost = 7 // INF, было player_cost = 4 | Нынешнее значение основано на количестве игроков в авейке ~bear1ake
 	spawn_weight = 0.67
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/ascent,

--- a/maps/away/ascent/ascent.dm
+++ b/maps/away/ascent/ascent.dm
@@ -12,7 +12,7 @@
 	suffixes = list("ascent/ascent-1.dmm")
 	spawn_cost = 0.5
 	player_cost = 7 // INF, было player_cost = 4 | Нынешнее значение основано на количестве игроков в авейке ~bear1ake
-	spawn_weight = 0.67
+	spawn_weight = 1 // INF, spawn_weight = 0.67
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/ascent,
 		/datum/shuttle/autodock/overmap/ascent/two

--- a/maps/away/away_sites.dm
+++ b/maps/away/away_sites.dm
@@ -1,7 +1,7 @@
 // Hey! Listen! Update \config\away_site_blacklist.txt with your new ruins!
 
 /datum/map_template/ruin/away_site
-//	var/spawn_weight = 1 // Определено в code/datums/ruins.dm ~bear1ake
+//	var/spawn_weight = 1 // INF Определено в code/datums/ruins.dm ~bear1ake
 	var/list/generate_mining_by_z
 	prefix = "maps/away/"
 

--- a/maps/away/away_sites.dm
+++ b/maps/away/away_sites.dm
@@ -1,7 +1,7 @@
 // Hey! Listen! Update \config\away_site_blacklist.txt with your new ruins!
 
 /datum/map_template/ruin/away_site
-	var/spawn_weight = 1
+//	var/spawn_weight = 1 // Определено в code/datums/ruins.dm ~bear1ake
 	var/list/generate_mining_by_z
 	prefix = "maps/away/"
 

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -34,7 +34,8 @@
 	id = "awaysite_bearcat_wreck"
 	description = "A wrecked light freighter."
 	suffixes = list("bearcat/bearcat-1.dmm", "bearcat/bearcat-2.dmm")
-	cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 //INF, WAS 1
+	player_cost = 4
 	spawn_weight = 0.67 //INF
 	shuttles_to_initialise = list(/datum/shuttle/autodock/ferry/lift)
 	area_usage_test_exempted_root_areas = list(/area/ship)

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -34,7 +34,7 @@
 	id = "awaysite_bearcat_wreck"
 	description = "A wrecked light freighter."
 	suffixes = list("bearcat/bearcat-1.dmm", "bearcat/bearcat-2.dmm")
-	spawn_cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 // INF, WAS 1
 	player_cost = 4
 	spawn_weight = 1 // INF, spawn_weight = 0.67
 	shuttles_to_initialise = list(/datum/shuttle/autodock/ferry/lift)

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -36,7 +36,7 @@
 	suffixes = list("bearcat/bearcat-1.dmm", "bearcat/bearcat-2.dmm")
 	spawn_cost = 0.5 //INF, WAS 1
 	player_cost = 4
-	spawn_weight = 0.67 //INF
+	spawn_weight = 1 // INF, spawn_weight = 0.67
 	shuttles_to_initialise = list(/datum/shuttle/autodock/ferry/lift)
 	area_usage_test_exempted_root_areas = list(/area/ship)
 	apc_test_exempt_areas = list(

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -29,7 +29,7 @@
 	id = "awaysite_casino"
 	description = "A casino ship!"
 	suffixes = list("casino/casino.dmm")
-	cost = 1
+	spawn_cost = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/casino_cutter)
 	area_usage_test_exempted_root_areas = list(/area/casino)
 	apc_test_exempt_areas = list(

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -29,7 +29,7 @@
 	id = "awaysite_casino"
 	description = "A casino ship!"
 	suffixes = list("casino/casino.dmm")
-	spawn_cost = 1
+	spawn_cost = 0.5 //INF, WAS 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/casino_cutter)
 	area_usage_test_exempted_root_areas = list(/area/casino)
 	apc_test_exempt_areas = list(

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -29,7 +29,7 @@
 	id = "awaysite_casino"
 	description = "A casino ship!"
 	suffixes = list("casino/casino.dmm")
-	spawn_cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 // INF, WAS 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/casino_cutter)
 	area_usage_test_exempted_root_areas = list(/area/casino)
 	apc_test_exempt_areas = list(

--- a/maps/away/derelict/derelict.dm
+++ b/maps/away/derelict/derelict.dm
@@ -21,7 +21,7 @@
 	id = "awaysite_derelict"
 	description = "An abandoned construction project."
 	suffixes = list("derelict/derelict-station.dmm")
-	cost = 1
+	spawn_cost = 1
 	accessibility_weight = 10
 	area_usage_test_exempted_areas = list(/area/AIsattele)
 	area_usage_test_exempted_root_areas = list(/area/constructionsite, /area/derelict)

--- a/maps/away/derelict/derelict.dm
+++ b/maps/away/derelict/derelict.dm
@@ -21,7 +21,7 @@
 	id = "awaysite_derelict"
 	description = "An abandoned construction project."
 	suffixes = list("derelict/derelict-station.dmm")
-	spawn_cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 // INF, WAS 1
 	accessibility_weight = 10
 	area_usage_test_exempted_areas = list(/area/AIsattele)
 	area_usage_test_exempted_root_areas = list(/area/constructionsite, /area/derelict)

--- a/maps/away/derelict/derelict.dm
+++ b/maps/away/derelict/derelict.dm
@@ -21,7 +21,7 @@
 	id = "awaysite_derelict"
 	description = "An abandoned construction project."
 	suffixes = list("derelict/derelict-station.dmm")
-	spawn_cost = 1
+	spawn_cost = 0.5 //INF, WAS 1
 	accessibility_weight = 10
 	area_usage_test_exempted_areas = list(/area/AIsattele)
 	area_usage_test_exempted_root_areas = list(/area/constructionsite, /area/derelict)

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -13,7 +13,7 @@
 	id = "awaysite_errant_pisces"
 	description = "Xynergy carp trawler"
 	suffixes = list("errant_pisces/errant_pisces.dmm")
-	spawn_cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 // INF, WAS 1
 	area_usage_test_exempted_root_areas = list(/area/errant_pisces)
 
 /mob/living/simple_animal/hostile/carp/shark // generally stronger version of a carp that doesn't die from a mean look. Fance new sprites included, credits to F-Tang Steve

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -13,7 +13,7 @@
 	id = "awaysite_errant_pisces"
 	description = "Xynergy carp trawler"
 	suffixes = list("errant_pisces/errant_pisces.dmm")
-	spawn_cost = 1
+	spawn_cost = 0.5 //INF, WAS 1
 	area_usage_test_exempted_root_areas = list(/area/errant_pisces)
 
 /mob/living/simple_animal/hostile/carp/shark // generally stronger version of a carp that doesn't die from a mean look. Fance new sprites included, credits to F-Tang Steve

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -13,7 +13,7 @@
 	id = "awaysite_errant_pisces"
 	description = "Xynergy carp trawler"
 	suffixes = list("errant_pisces/errant_pisces.dmm")
-	cost = 1
+	spawn_cost = 1
 	area_usage_test_exempted_root_areas = list(/area/errant_pisces)
 
 /mob/living/simple_animal/hostile/carp/shark // generally stronger version of a carp that doesn't die from a mean look. Fance new sprites included, credits to F-Tang Steve

--- a/maps/away/icarus/icarus.dm
+++ b/maps/away/icarus/icarus.dm
@@ -41,7 +41,7 @@
 	id = "awaysite_icarus"
 	description = "The crashlanding site of the SEV Icarus."
 	suffixes = list("icarus/icarus-1.dmm", "icarus/icarus-2.dmm")
-	cost = 2
+	spawn_cost = 2
 	generate_mining_by_z = list(1, 2)
 	area_usage_test_exempted_root_areas = list(/area/icarus)
 	area_coherency_test_exempt_areas = list(/area/icarus/vessel, /area/icarus/open)

--- a/maps/away/lar_maria/lar_maria.dm
+++ b/maps/away/lar_maria/lar_maria.dm
@@ -11,7 +11,7 @@
 	id = "awaysite_lar_maria"
 	description = "An orbital virus research station."
 	suffixes = list("lar_maria/lar_maria-1.dmm", "lar_maria/lar_maria-2.dmm")
-	cost = 1 //INF, WAS 2
+	spawn_cost = 1 //INF, WAS 2
 	area_usage_test_exempted_root_areas = list(/area/lar_maria)
 
 ///////////////////////////////////crew and prisoners

--- a/maps/away/lar_maria/lar_maria.dm
+++ b/maps/away/lar_maria/lar_maria.dm
@@ -11,7 +11,7 @@
 	id = "awaysite_lar_maria"
 	description = "An orbital virus research station."
 	suffixes = list("lar_maria/lar_maria-1.dmm", "lar_maria/lar_maria-2.dmm")
-	spawn_cost = 1 //INF, WAS 2
+	spawn_cost = 1 // INF, WAS 2
 	area_usage_test_exempted_root_areas = list(/area/lar_maria)
 
 ///////////////////////////////////crew and prisoners

--- a/maps/away/lost_supply_base/lost_supply_base.dm
+++ b/maps/away/lost_supply_base/lost_supply_base.dm
@@ -19,7 +19,7 @@
 	id = "awaysite_lost_supply_base"
 	description = "An abandoned supply base."
 	suffixes = list("lost_supply_base/lost_supply_base.dmm")
-	spawn_cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 // INF, WAS 1
 	generate_mining_by_z = 1
 	area_usage_test_exempted_root_areas = list(/area/lost_supply_base)
 	apc_test_exempt_areas = list(

--- a/maps/away/lost_supply_base/lost_supply_base.dm
+++ b/maps/away/lost_supply_base/lost_supply_base.dm
@@ -19,7 +19,7 @@
 	id = "awaysite_lost_supply_base"
 	description = "An abandoned supply base."
 	suffixes = list("lost_supply_base/lost_supply_base.dmm")
-	cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 //INF, WAS 1
 	generate_mining_by_z = 1
 	area_usage_test_exempted_root_areas = list(/area/lost_supply_base)
 	apc_test_exempt_areas = list(

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -19,7 +19,7 @@
 	id = "awaysite_magshield"
 	description = "It's an orbital shield station."
 	suffixes = list("magshield/magshield.dmm")
-	cost = 1
+	spawn_cost = 1
 	area_usage_test_exempted_root_areas = list(/area/magshield)
 
 /obj/effect/shuttle_landmark/nav_magshield/nav1

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -19,7 +19,7 @@
 	id = "awaysite_magshield"
 	description = "It's an orbital shield station."
 	suffixes = list("magshield/magshield.dmm")
-	spawn_cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 // INF, WAS 1
 	area_usage_test_exempted_root_areas = list(/area/magshield)
 
 /obj/effect/shuttle_landmark/nav_magshield/nav1

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -19,7 +19,7 @@
 	id = "awaysite_magshield"
 	description = "It's an orbital shield station."
 	suffixes = list("magshield/magshield.dmm")
-	spawn_cost = 1
+	spawn_cost = 0.5 //INF, WAS 1
 	area_usage_test_exempted_root_areas = list(/area/magshield)
 
 /obj/effect/shuttle_landmark/nav_magshield/nav1

--- a/maps/away/meatstation/meatstation.dm
+++ b/maps/away/meatstation/meatstation.dm
@@ -18,7 +18,7 @@
 	id = "awaysite_meatstation"
 	description = "It's a research station full of baddies and some unique loot."
 	suffixes = list("meatstation/meatstation.dmm")
-	spawn_cost = 1
+	spawn_cost = 0.5 //INF, WAS 1
 	area_usage_test_exempted_root_areas = list(/area/meatstation)
 
 /obj/effect/shuttle_landmark/nav_meatstation/nav1

--- a/maps/away/meatstation/meatstation.dm
+++ b/maps/away/meatstation/meatstation.dm
@@ -18,7 +18,7 @@
 	id = "awaysite_meatstation"
 	description = "It's a research station full of baddies and some unique loot."
 	suffixes = list("meatstation/meatstation.dmm")
-	spawn_cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 // INF, WAS 1
 	area_usage_test_exempted_root_areas = list(/area/meatstation)
 
 /obj/effect/shuttle_landmark/nav_meatstation/nav1

--- a/maps/away/meatstation/meatstation.dm
+++ b/maps/away/meatstation/meatstation.dm
@@ -18,7 +18,7 @@
 	id = "awaysite_meatstation"
 	description = "It's a research station full of baddies and some unique loot."
 	suffixes = list("meatstation/meatstation.dmm")
-	cost = 1
+	spawn_cost = 1
 	area_usage_test_exempted_root_areas = list(/area/meatstation)
 
 /obj/effect/shuttle_landmark/nav_meatstation/nav1

--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -29,7 +29,7 @@
 	id = "awaysite_mining_asteroid"
 	description = "A medium-sized asteroid full of minerals."
 	suffixes = list("mining/mining-asteroid.dmm")
-	cost = 1
+	spawn_cost = 1
 	accessibility_weight = 10
 	generate_mining_by_z = 1
 	apc_test_exempt_areas = list(
@@ -100,7 +100,7 @@
 	id = "awaysite_mining_signal"
 	description = "A mineral-rich, formerly-volcanic site on a planetoid."
 	suffixes = list("mining/mining-signal.dmm")
-	cost = 1
+	spawn_cost = 1
 	generate_mining_by_z = 1
 	base_turf_for_zs = /turf/simulated/floor/asteroid
 	area_usage_test_exempted_root_areas = list(/area/mine, /area/outpost)
@@ -168,7 +168,7 @@
 	id = "awaysite_mining_orb"
 	description = "A sort of circular asteroid with a bird."
 	suffixes = list("mining/mining-orb.dmm")
-	cost = 10
+	spawn_cost = 10
 	accessibility_weight = 10
 	generate_mining_by_z = 1
 	base_turf_for_zs = /turf/simulated/floor/asteroid

--- a/maps/away/miningstation/miningstation.dm
+++ b/maps/away/miningstation/miningstation.dm
@@ -13,7 +13,7 @@
 	description = "An orbital Mining Station bearing authentication codes from Grayson Mining Industries, sensors show inconsistant lifesigns aboard the station."
 	suffixes = list("miningstation/miningstation.dmm")
 	prefix = "maps/away_inf/" //INF
-	cost = 1
+	spawn_cost = 1
 	area_usage_test_exempted_root_areas = list(/area/miningstation)
 
 ///////////////////////////////////crew

--- a/maps/away/mobius_rift/mobius_rift.dm
+++ b/maps/away/mobius_rift/mobius_rift.dm
@@ -11,7 +11,7 @@
 	id = "awaysite_mobius_rift"
 	description = "Non-euclidian mess."
 	suffixes = list("mobius_rift/mobius_rift.dmm")
-	cost = 1
+	spawn_cost = 1
 	area_usage_test_exempted_root_areas = list(/area/mobius_rift)
 	apc_test_exempt_areas = list(
 		/area/mobius_rift = NO_SCRUBBER|NO_VENT|NO_APC

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -10,7 +10,7 @@
 	suffixes = list("skrellscoutship/skrellscoutship_revamp.dmm")
 	spawn_cost = 0.5
 	player_cost = 6 // INF, было player_cost = 4 | Нынешнее значение основано на количестве игроков в авейке ~bear1ake
-	spawn_weight = 0.67 //INF
+	spawn_weight = 1 // INF, spawn_weight = 0.67
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/skrellscoutship, /datum/shuttle/autodock/overmap/skrellscoutshuttle)
 	apc_test_exempt_areas = list(
 		/area/ship/skrellscoutship/externalwing/port = NO_SCRUBBER|NO_VENT|NO_APC,

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -8,7 +8,8 @@
 	id = "awaysite_skrell_scout"
 	description = "A Skrellian SDTF scouting vessel."
 	suffixes = list("skrellscoutship/skrellscoutship_revamp.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
+	player_cost = 6 // INF, было player_cost = 4 | Нынешнее значение основано на количестве игроков в авейке ~bear1ake
 	spawn_weight = 0.67 //INF
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/skrellscoutship, /datum/shuttle/autodock/overmap/skrellscoutshuttle)
 	apc_test_exempt_areas = list(

--- a/maps/away/slavers/slavers_base.dm
+++ b/maps/away/slavers/slavers_base.dm
@@ -22,7 +22,7 @@
 	id = "awaysite_slavers"
 	description = "Asteroid with slavers base inside."
 	suffixes = list("slavers/slavers_base.dmm")
-	spawn_cost = 1
+	spawn_cost = 0.5 //INF, WAS 1
 	generate_mining_by_z = 1
 	area_usage_test_exempted_root_areas = list(/area/slavers_base)
 	apc_test_exempt_areas = list(

--- a/maps/away/slavers/slavers_base.dm
+++ b/maps/away/slavers/slavers_base.dm
@@ -22,7 +22,7 @@
 	id = "awaysite_slavers"
 	description = "Asteroid with slavers base inside."
 	suffixes = list("slavers/slavers_base.dmm")
-	spawn_cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 // INF, WAS 1
 	generate_mining_by_z = 1
 	area_usage_test_exempted_root_areas = list(/area/slavers_base)
 	apc_test_exempt_areas = list(

--- a/maps/away/slavers/slavers_base.dm
+++ b/maps/away/slavers/slavers_base.dm
@@ -22,7 +22,7 @@
 	id = "awaysite_slavers"
 	description = "Asteroid with slavers base inside."
 	suffixes = list("slavers/slavers_base.dmm")
-	cost = 1
+	spawn_cost = 1
 	generate_mining_by_z = 1
 	area_usage_test_exempted_root_areas = list(/area/slavers_base)
 	apc_test_exempt_areas = list(

--- a/maps/away/smugglers/smugglers.dm
+++ b/maps/away/smugglers/smugglers.dm
@@ -17,7 +17,7 @@
 	id = "awaysite_smugglers"
 	description = "Yarr."
 	suffixes = list("smugglers/smugglers.dmm")
-	cost = 1
+	spawn_cost = 1
 	generate_mining_by_z = 1
 	area_usage_test_exempted_root_areas = list(/area/smugglers)
 	apc_test_exempt_areas = list(

--- a/maps/away/unishi/unishi.dm
+++ b/maps/away/unishi/unishi.dm
@@ -30,7 +30,7 @@
 	id = "awaysite_unishi"
 	description = "CTI research ship.."
 	suffixes = list("unishi/unishi-1.dmm", "unishi/unishi-2.dmm", "unishi/unishi-3.dmm")
-	spawn_cost = 2000 //inf, was 2, we aren't using it
+	spawn_cost = 2000 // INF, was 2, we aren't using it
 	area_usage_test_exempted_root_areas = list(/area/unishi)
 
 

--- a/maps/away/unishi/unishi.dm
+++ b/maps/away/unishi/unishi.dm
@@ -30,7 +30,7 @@
 	id = "awaysite_unishi"
 	description = "CTI research ship.."
 	suffixes = list("unishi/unishi-1.dmm", "unishi/unishi-2.dmm", "unishi/unishi-3.dmm")
-	cost = 2000 //inf, was 2, we aren't using it
+	spawn_cost = 2000 //inf, was 2, we aren't using it
 	area_usage_test_exempted_root_areas = list(/area/unishi)
 
 

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -9,7 +9,7 @@
 	description = "Vox ship and base."
 	suffixes = list("voxship/voxship-1.dmm")
 	spawn_weight = 50 //INF, HABITABLE SHIPS SPAWN
-	cost = 9999 //INF, WAS 0.5
+	spawn_cost = 9999 //INF, WAS 0.5
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_shuttle)
 	area_usage_test_exempted_root_areas = list(/area/voxship)
 	ban_ruins = list(/datum/map_template/ruin/away_site/scavship)
@@ -94,7 +94,8 @@
 	id = "awaysite_voxship2"
 	description = "Vox Scavenger Ship."
 	suffixes = list("voxship/voxship-2.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
+	player_cost = 5 // INF, было player_cost = 4 | Нынешнее значение основано на количестве игроков в авейке ~bear1ake
 	spawn_weight = 0.67 //INF
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_ship, /datum/shuttle/autodock/overmap/vox_lander)
 	ban_ruins = list(/datum/map_template/ruin/away_site/voxship)

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -96,7 +96,7 @@
 	suffixes = list("voxship/voxship-2.dmm")
 	spawn_cost = 0.5
 	player_cost = 5 // INF, было player_cost = 4 | Нынешнее значение основано на количестве игроков в авейке ~bear1ake
-	spawn_weight = 0.67 //INF
+	spawn_weight = 1 // INF, spawn_weight = 0.67
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_ship, /datum/shuttle/autodock/overmap/vox_lander)
 	ban_ruins = list(/datum/map_template/ruin/away_site/voxship)
 

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -9,7 +9,7 @@
 	description = "Vox ship and base."
 	suffixes = list("voxship/voxship-1.dmm")
 	spawn_weight = 50 //INF, HABITABLE SHIPS SPAWN
-	spawn_cost = 9999 //INF, WAS 0.5
+	spawn_cost = 9999 // INF, WAS 0.5
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_shuttle)
 	area_usage_test_exempted_root_areas = list(/area/voxship)
 	ban_ruins = list(/datum/map_template/ruin/away_site/scavship)

--- a/maps/away/yacht/yacht.dm
+++ b/maps/away/yacht/yacht.dm
@@ -22,7 +22,7 @@
 	id = "awaysite_yach"
 	description = "Tiny movable ship with spiders."
 	suffixes = list("yacht/yacht.dmm")
-	cost = 10
+	spawn_cost = 10
 	area_usage_test_exempted_root_areas = list(/area/yacht)
 
 /obj/effect/shuttle_landmark/nav_yacht/nav1

--- a/maps/away_inf/adherent_base/adherent_base.dm
+++ b/maps/away_inf/adherent_base/adherent_base.dm
@@ -18,7 +18,7 @@
 	description = "There is faint \"S.O.S.\" signal incoming from the water surface. Decyphering codes are very old."
 	prefix = "maps/away_inf/"
 	suffixes = list("adherent_base/adherent_base_1.dmm", "adherent_base/adherent_base_2.dmm", "adherent_base/adherent_base_3.dmm")
-	cost = 1000	//event only
+	spawn_cost = 1000	//event only
 
 /obj/effect/shuttle_landmark/adherent_base/nav1
 	name = "Aquatic Planet - Island Landing Area"

--- a/maps/away_inf/ascent/ascent.dm
+++ b/maps/away_inf/ascent/ascent.dm
@@ -11,7 +11,7 @@
 	description = "A small Ascent colony ship. Looks like it was damaged."
 	prefix = "maps/away_inf/"
 	suffixes = list("ascent/ascent-1.dmm")
-	cost = 1000 //INF WAS 2
+	spawn_cost = 1000 //INF WAS 2
 	spawn_weight = 50 //HABITABLE SHIPS SPAWN
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/ascent_inf,

--- a/maps/away_inf/ascent/ascent.dm
+++ b/maps/away_inf/ascent/ascent.dm
@@ -11,7 +11,7 @@
 	description = "A small Ascent colony ship. Looks like it was damaged."
 	prefix = "maps/away_inf/"
 	suffixes = list("ascent/ascent-1.dmm")
-	spawn_cost = 1000 //INF WAS 2
+	spawn_cost = 1000 // Отключено до лучших времен. Было 2 ~Laxesh
 	spawn_weight = 50 //HABITABLE SHIPS SPAWN
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/ascent_inf,

--- a/maps/away_inf/bearcat/bearcat.dm
+++ b/maps/away_inf/bearcat/bearcat.dm
@@ -38,7 +38,7 @@
 	description = "A wrecked light freighter."
 	prefix = "maps/away_inf/"
 	suffixes = list("bearcat/bearcat-1.dmm", "bearcat/bearcat-2.dmm")
-	spawn_cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 // INF, WAS 1
 	player_cost = 4 // Нынешнее значение основано на количестве игроков в авейке ~bear1ake
 	spawn_weight = 1 // INF, spawn_weight = 0.67
 	shuttles_to_initialise = list(/datum/shuttle/autodock/ferry/lift, /datum/shuttle/autodock/overmap/exploration)

--- a/maps/away_inf/bearcat/bearcat.dm
+++ b/maps/away_inf/bearcat/bearcat.dm
@@ -38,7 +38,8 @@
 	description = "A wrecked light freighter."
 	prefix = "maps/away_inf/"
 	suffixes = list("bearcat/bearcat-1.dmm", "bearcat/bearcat-2.dmm")
-	cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 //INF, WAS 1
+	player_cost = 4 // Нынешнее значение основано на количестве игроков в авейке ~bear1ake
 	spawn_weight = 0.67 //INF
 	shuttles_to_initialise = list(/datum/shuttle/autodock/ferry/lift, /datum/shuttle/autodock/overmap/exploration)
 	area_usage_test_exempted_root_areas = list(/area/ship)

--- a/maps/away_inf/bearcat/bearcat.dm
+++ b/maps/away_inf/bearcat/bearcat.dm
@@ -40,7 +40,7 @@
 	suffixes = list("bearcat/bearcat-1.dmm", "bearcat/bearcat-2.dmm")
 	spawn_cost = 0.5 //INF, WAS 1
 	player_cost = 4 // Нынешнее значение основано на количестве игроков в авейке ~bear1ake
-	spawn_weight = 0.67 //INF
+	spawn_weight = 1 // INF, spawn_weight = 0.67
 	shuttles_to_initialise = list(/datum/shuttle/autodock/ferry/lift, /datum/shuttle/autodock/overmap/exploration)
 	area_usage_test_exempted_root_areas = list(/area/ship)
 	apc_test_exempt_areas = list(

--- a/maps/away_inf/blueriver/blueriver.dm
+++ b/maps/away_inf/blueriver/blueriver.dm
@@ -27,7 +27,7 @@
 	name = "Bluespace River"
 	id = "awaysite_blue"
 	description = "Two z-level map with an arctic planet and an alien underground surface"
-	cost = 1 //WAS 0.5
+	spawn_cost = 1 //WAS 0.5
 	generate_mining_by_z = 2
 	prefix = "maps/away_inf/"
 	suffixes = list("blueriver/blueriver-1.dmm", "blueriver/blueriver-2.dmm")

--- a/maps/away_inf/blueriver/blueriver.dm
+++ b/maps/away_inf/blueriver/blueriver.dm
@@ -27,7 +27,7 @@
 	name = "Bluespace River"
 	id = "awaysite_blue"
 	description = "Two z-level map with an arctic planet and an alien underground surface"
-	spawn_cost = 1 //WAS 0.5
+	spawn_cost = 1 // WAS 0.5
 	generate_mining_by_z = 2
 	prefix = "maps/away_inf/"
 	suffixes = list("blueriver/blueriver-1.dmm", "blueriver/blueriver-2.dmm")

--- a/maps/away_inf/gunboat/gunboat.dm
+++ b/maps/away_inf/gunboat/gunboat.dm
@@ -28,7 +28,7 @@
 	description = "Property of SCG - carrier of torpedos, one laser and a small crew."
 	prefix = "maps/away_inf/"
 	suffixes = list("gunboat/gunboat-1.dmm", "gunboat/gunboat-2.dmm")
-	cost = 1000
+	spawn_cost = 1000
 
 /obj/effect/shuttle_landmark/nav_gunboat/nav1
 	name = "Gunboat Navpoint #1"

--- a/maps/away_inf/liberia/liberia.dm
+++ b/maps/away_inf/liberia/liberia.dm
@@ -12,7 +12,8 @@
 	description = "A Merchant ship." //Описание
 	prefix = "maps/away_inf/" //Префикс
 	suffixes = list("liberia/liberia.dmm") //Суффикс
-	cost = 0 //Стоимость
+	spawn_cost = 0 //Стоимость самой авейки
+	player_cost = 0 //Стоимость авейки в игроках
 	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 	spawn_weight = 50 //HABITABLE SHIPS SPAWN | Шанс спавна. Нельзя ставить 0, иначе подбор авеек сломается. Дробные допускаются, желательно до сотых ~bear1ake
 	//Инициализация шаттлов

--- a/maps/away_inf/marksman/marksman.dm
+++ b/maps/away_inf/marksman/marksman.dm
@@ -40,7 +40,7 @@
 	description = "A broken, drifting ship. They had a mission to save SEV Torch's crew."
 	prefix = "maps/away_inf/"
 	suffixes = list("marksman/marksman-1.dmm", "marksman/marksman-2.dmm")
-	cost = 1000
+	spawn_cost = 1000
 
 /obj/effect/shuttle_landmark/marksman/nav1
 	name = "Drifting Ship Fore"

--- a/maps/away_inf/merchant/merchant.dm
+++ b/maps/away_inf/merchant/merchant.dm
@@ -23,7 +23,7 @@
 	id = "awaysite_merchant"
 	description = "Small vessel with merchpad."
 	suffixes = list("merchant/merchant-1.dmm", "merchant/merchant-2.dmm")
-	cost = 1000 //Event?
+	spawn_cost = 1000 //Event?
 */
 /obj/effect/shuttle_landmark/nav_merchant/nav1
 	name = "Merchant Navpoint #1"

--- a/maps/away_inf/mining/mining.dm
+++ b/maps/away_inf/mining/mining.dm
@@ -37,7 +37,7 @@
 	description = "A medium-sized asteroid full of minerals. Old mining facility detected at one of sides, owner - NanoTrasen."
 	prefix = "maps/away_inf/"
 	suffixes = list("mining/mining-asteroid.dmm")
-	spawn_cost = 1 //WAS 0.5
+	spawn_cost = 1 // WAS 0.5
 	accessibility_weight = 10
 	generate_mining_by_z = 1
 	apc_test_exempt_areas = list(

--- a/maps/away_inf/mining/mining.dm
+++ b/maps/away_inf/mining/mining.dm
@@ -37,7 +37,7 @@
 	description = "A medium-sized asteroid full of minerals. Old mining facility detected at one of sides, owner - NanoTrasen."
 	prefix = "maps/away_inf/"
 	suffixes = list("mining/mining-asteroid.dmm")
-	cost = 1 //WAS 0.5
+	spawn_cost = 1 //WAS 0.5
 	accessibility_weight = 10
 	generate_mining_by_z = 1
 	apc_test_exempt_areas = list(

--- a/maps/away_inf/mining/mining.dm
+++ b/maps/away_inf/mining/mining.dm
@@ -125,7 +125,7 @@
 	id = "awaysite_mining_signal"
 	description = "A mineral-rich, formerly-volcanic site on a planetoid."
 	suffixes = list("mining/mining-signal.dmm")
-	cost = 1
+	spawn_cost = 1
 	base_turf_for_zs = /turf/simulated/floor/asteroid
 
 /obj/effect/shuttle_landmark/away

--- a/maps/away_inf/salvagers/salvagers.dm
+++ b/maps/away_inf/salvagers/salvagers.dm
@@ -78,7 +78,7 @@
 	description = "A light trader vessel."
 	prefix = "maps/away_inf/"
 	suffixes = list("salvagers/salvagers.dmm")
-	cost = 0
+	spawn_cost = 0
 	accessibility_weight = 10
 	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 

--- a/maps/away_inf/sentinel/sentinel.dm
+++ b/maps/away_inf/sentinel/sentinel.dm
@@ -48,7 +48,7 @@
 	suffixes = list("sentinel/sentinel-1.dmm", "sentinel/sentinel-2.dmm")
 	spawn_cost = 0.5
 	player_cost = 7 // Нынешнее значение основано на количестве игроков в авейке ~bear1ake
-	spawn_weight = 1 // INF, spawn_weight = 0.67
+	spawn_weight = 1 // INF, spawn_weight = 0.5
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/reaper)
 
 

--- a/maps/away_inf/sentinel/sentinel.dm
+++ b/maps/away_inf/sentinel/sentinel.dm
@@ -46,7 +46,8 @@
 	description = "Nagashino-class Multipurpose Patrol Craft."
 	prefix = "maps/away_inf/"
 	suffixes = list("sentinel/sentinel-1.dmm", "sentinel/sentinel-2.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
+	player_cost = 7 // Нынешнее значение основано на количестве игроков в авейке ~bear1ake
 	spawn_weight = 0.5 //INF
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/reaper)
 

--- a/maps/away_inf/sentinel/sentinel.dm
+++ b/maps/away_inf/sentinel/sentinel.dm
@@ -48,7 +48,7 @@
 	suffixes = list("sentinel/sentinel-1.dmm", "sentinel/sentinel-2.dmm")
 	spawn_cost = 0.5
 	player_cost = 7 // Нынешнее значение основано на количестве игроков в авейке ~bear1ake
-	spawn_weight = 0.5 //INF
+	spawn_weight = 1 // INF, spawn_weight = 0.67
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/reaper)
 
 

--- a/maps/away_inf/shipcrash/shipcrash.dm
+++ b/maps/away_inf/shipcrash/shipcrash.dm
@@ -18,7 +18,7 @@
 	description = "Grayson mining vessel"
 	prefix = "maps/away_inf/"
 	suffixes = list("shipcrash/shipcrash.dmm")
-	cost = 1
+	spawn_cost = 1
 	accessibility_weight = 10
 //	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED //UNCOMMENT THIS FOR TESTING PURPOSES; MAKES MAP SPAWNING EVERY ROUND
 	area_usage_test_exempted_root_areas = list(/area/shipcrash)

--- a/maps/away_inf/skrellscoutship/skrellscoutship.dm
+++ b/maps/away_inf/skrellscoutship/skrellscoutship.dm
@@ -12,7 +12,7 @@
 	prefix = "maps/away_inf/"
 	suffixes = list("skrellscoutship/skrellscoutship-1.dmm", "skrellscoutship/skrellscoutship-2.dmm")
 	spawn_weight = 50 //INF, HABITABLE SHIPS SPAWN
-	cost = 2000
+	spawn_cost = 2000
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/skrellscoutship, /datum/shuttle/autodock/overmap/skrellscoutshuttle)
 	apc_test_exempt_areas = list(
 		/area/ship/skrellscoutshuttle =                NO_SCRUBBER|NO_VENT|NO_APC,

--- a/maps/away_inf/smugglers/smugglers.dm
+++ b/maps/away_inf/smugglers/smugglers.dm
@@ -20,7 +20,7 @@
 	description = "Yarr."
 	prefix = "maps/away_inf/"
 	suffixes = list("smugglers/smugglers.dmm")
-	spawn_cost = 1 //WAS 0.5
+	spawn_cost = 1 // WAS 0.5
 	generate_mining_by_z = 1
 	area_usage_test_exempted_root_areas = list(/area/smugglers)
 	apc_test_exempt_areas = list(

--- a/maps/away_inf/smugglers/smugglers.dm
+++ b/maps/away_inf/smugglers/smugglers.dm
@@ -20,7 +20,7 @@
 	description = "Yarr."
 	prefix = "maps/away_inf/"
 	suffixes = list("smugglers/smugglers.dmm")
-	cost = 1 //WAS 0.5
+	spawn_cost = 1 //WAS 0.5
 	generate_mining_by_z = 1
 	area_usage_test_exempted_root_areas = list(/area/smugglers)
 	apc_test_exempt_areas = list(

--- a/maps/away_inf/white_star/white_star.dm
+++ b/maps/away_inf/white_star/white_star.dm
@@ -13,7 +13,7 @@
  	id = "white_star"
  	prefix = "maps/away_inf/"
  	suffixes = list("white_star/white_star.dmm")
- 	cost = 1000
+ 	spawn_cost = 1000
 
 /*obj/effect/overmap/ship/white_star_alt
 	name = "Unidentified ship"

--- a/maps/away_inf/yacht/yacht.dm
+++ b/maps/away_inf/yacht/yacht.dm
@@ -30,7 +30,7 @@
 	suffixes = list("yacht/yacht.dmm")
 	spawn_cost = 0.5
 	player_cost = 2 // Нынешнее значение основано на количестве игроков в авейке ~bear1ake
-	spawn_weight = 0.67 //INF
+	spawn_weight = 1 // INF, spawn_weight = 0.67
 	area_usage_test_exempted_root_areas = list(/area/yacht)
 
 /obj/effect/shuttle_landmark/nav_yacht/nav1

--- a/maps/away_inf/yacht/yacht.dm
+++ b/maps/away_inf/yacht/yacht.dm
@@ -30,7 +30,7 @@
 	suffixes = list("yacht/yacht.dmm")
 	spawn_cost = 0.5
 	player_cost = 2 // Нынешнее значение основано на количестве игроков в авейке ~bear1ake
-	spawn_weight = 1 // INF, spawn_weight = 0.67
+	spawn_weight = 1 // было spawn_weight = 0.67
 	area_usage_test_exempted_root_areas = list(/area/yacht)
 
 /obj/effect/shuttle_landmark/nav_yacht/nav1

--- a/maps/away_inf/yacht/yacht.dm
+++ b/maps/away_inf/yacht/yacht.dm
@@ -28,7 +28,8 @@
 	description = "Tiny movable ship with ~spiders~ riches."
 	prefix = "maps/away_inf/"
 	suffixes = list("yacht/yacht.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
+	player_cost = 2 // Нынешнее значение основано на количестве игроков в авейке ~bear1ake
 	spawn_weight = 0.67 //INF
 	area_usage_test_exempted_root_areas = list(/area/yacht)
 

--- a/maps/random_ruins/exoplanet_ruins/bunker/bunker.dm
+++ b/maps/random_ruins/exoplanet_ruins/bunker/bunker.dm
@@ -4,7 +4,7 @@
 	id = "planetsite_bunker"
 	description = "Bunch of monoliths surrounding an artifact."
 	suffixes = list("bunker/bunker.dmm")
-	cost = 1
+	spawn_cost = 1
 
 /obj/machinery/telecomms/relay/preset/bunker
 	id = "Bunker Relay"

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	id = "crashed_pod"
 	description = "A crashed survival pod from a destroyed ship."
 	suffixes = list("crashed_pod/crashed_pod.dmm")
-	cost = 2
+	spawn_cost = 2
 	player_cost = 1 // INF, было player_cost = 4 | Нынешнее значение основано на количестве игроков в авейке ~bear1ake
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -6,6 +6,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	description = "A crashed survival pod from a destroyed ship."
 	suffixes = list("crashed_pod/crashed_pod.dmm")
 	cost = 2
+	player_cost = 1 // INF, было player_cost = 4 | Нынешнее значение основано на количестве игроков в авейке ~bear1ake
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
 

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod_inf/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod_inf/crashed_pod.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	id = "crashed_pod"
 	description = "A crashed survival pod from a destroyed ship."
 	suffixes = list("crashed_pod_inf/crashed_pod.dmm")
-	cost = 2
+	spawn_cost = 2
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 
 /area/map_template/crashed_pod

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
@@ -3,7 +3,7 @@
 	id = "datacapsule"
 	description = "A damaged capsule with some strange contents."
 	suffixes = list("datacapsule/datacapsule.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
 

--- a/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dm
+++ b/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dm
@@ -3,6 +3,6 @@
 	id = "deserted_lab"
 	description = "A mid-sized abandoned lab with some enemies, traps, and loot."
 	suffixes = list("deserted_lab/deserted_lab.dmm")
-	cost = 1.5
+	spawn_cost = 1.5
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS|TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN

--- a/maps/random_ruins/exoplanet_ruins/drill_site/drill_site.dm
+++ b/maps/random_ruins/exoplanet_ruins/drill_site/drill_site.dm
@@ -3,6 +3,6 @@
 	id = "drill_site"
 	description = "A small, abandoned mining drill operation."
 	suffixes = list("drill_site/drill_site.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS|TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN

--- a/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dm
+++ b/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dm
@@ -3,7 +3,7 @@
 	id = "ec_old_wreck"
 	description = "An abandoned ancient STL exploration ship."
 	suffixes = list("ec_old_crash/ec_old_crash.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	apc_test_exempt_areas = list(
 		/area/map_template/ecship = 0,
 		/area/map_template/ecship/engine = NO_SCRUBBER|NO_VENT|NO_APC,

--- a/maps/random_ruins/exoplanet_ruins/fountain/fountain_ruin.dm
+++ b/maps/random_ruins/exoplanet_ruins/fountain/fountain_ruin.dm
@@ -3,6 +3,6 @@
 	id = "planetsite_fountain"
 	description = "The fountain of youth itself."
 	suffixes = list("fountain/fountain_ruin.dmm")
-	cost = 2
+	spawn_cost = 2
 	template_flags = TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_CLEAR_CONTENTS
 	ruin_tags = RUIN_ALIEN

--- a/maps/random_ruins/exoplanet_ruins/hut/hut.dm
+++ b/maps/random_ruins/exoplanet_ruins/hut/hut.dm
@@ -3,6 +3,6 @@
 	id = "hut"
 	description = "A small and simple little research hut."
 	suffixes = list("hut/hut.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS|TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
@@ -3,7 +3,7 @@
 	id = "exoplanet_hydrobase"
 	description = "hydroponics base with random plants and a lot of enemies"
 	suffixes = list("hydrobase/hydrobase.dmm")
-	cost = 2
+	spawn_cost = 2
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_ALIEN
 	apc_test_exempt_areas = list(

--- a/maps/random_ruins/exoplanet_ruins/lodge/lodge.dm
+++ b/maps/random_ruins/exoplanet_ruins/lodge/lodge.dm
@@ -3,7 +3,7 @@
 	id = "lodge"
 	description = "A wood cabin."
 	suffixes = list("lodge/lodge.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT
 

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
@@ -3,7 +3,7 @@
 	id = "awaysite_marooned" 
 	description = "crashed dropship with marooned Magnitka officer" 
 	suffixes = list("marooned/marooned.dmm") 
-	cost = 1 
+	spawn_cost = 1 
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
 	apc_test_exempt_areas = list(

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -3,7 +3,7 @@
 	id = "planetsite_monoliths"
 	description = "Bunch of monoliths surrounding an artifact."
 	suffixes = list("monoliths/monoliths.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_ALIEN
 

--- a/maps/random_ruins/exoplanet_ruins/oasis/oasis.dm
+++ b/maps/random_ruins/exoplanet_ruins/oasis/oasis.dm
@@ -3,7 +3,7 @@
 	id = "oasis1"
 	description = "A tiny patch of life in a vast desert."
 	suffixes = list("oasis/oasis.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	template_flags = TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_ALLOW_DUPLICATES
 	ruin_tags = RUIN_NATURAL|RUIN_WATER
 

--- a/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dm
@@ -4,7 +4,7 @@
 	id = "exoplanet_oldlab"
 	description = "an abandoned lab"
 	suffixes = list("oldlab/oldlab.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN
 

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dm
@@ -3,7 +3,7 @@
 	id = "oldpod"
 	description = "A now unused, crashed escape pod."
 	suffixes = list("oldpod/oldpod.dmm")
-	cost = 0.5
+	spawn_cost = 0.5
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
 	apc_test_exempt_areas = list(

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
@@ -3,7 +3,8 @@
 	id = "playablecolony"
 	description = "a fully functional colony on the frontier of settled space"
 	suffixes = list("playablecolony/colony.dmm")
-	cost = 2
+	spawn_cost = 2
+	player_cost = 6 // INF, было player_cost = 4 | Нынешнее значение основано на количестве игроков в авейке ~bear1ake
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT
 	apc_test_exempt_areas = list(

--- a/maps/random_ruins/exoplanet_ruins/playablecolony_inf/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony_inf/playablecolony.dm
@@ -3,7 +3,7 @@
 	id = "playablecolony"
 	description = "a fully functional colony on the frontier of settled space"
 	suffixes = list("playablecolony_inf/colony.dmm")
-	cost = 2000 //was 2, we aren't using it now
+	spawn_cost = 2000 //was 2, we aren't using it now
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT
 	apc_test_exempt_areas = list(

--- a/maps/random_ruins/exoplanet_ruins/playablecolony_inf/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony_inf/playablecolony.dm
@@ -3,7 +3,7 @@
 	id = "playablecolony"
 	description = "a fully functional colony on the frontier of settled space"
 	suffixes = list("playablecolony_inf/colony.dmm")
-	spawn_cost = 1
+	spawn_cost = 0.5 //INF, WAS 1
 	player_cost = 6 // Нынешнее значение основано на количестве игроков в авейке
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT

--- a/maps/random_ruins/exoplanet_ruins/playablecolony_inf/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony_inf/playablecolony.dm
@@ -3,7 +3,7 @@
 	id = "playablecolony"
 	description = "a fully functional colony on the frontier of settled space"
 	suffixes = list("playablecolony_inf/colony.dmm")
-	spawn_cost = 0.5 //INF, WAS 1
+	spawn_cost = 0.5 // было 1
 	player_cost = 6 // Нынешнее значение основано на количестве игроков в авейке
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT

--- a/maps/random_ruins/exoplanet_ruins/playablecolony_inf/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony_inf/playablecolony.dm
@@ -3,7 +3,8 @@
 	id = "playablecolony"
 	description = "a fully functional colony on the frontier of settled space"
 	suffixes = list("playablecolony_inf/colony.dmm")
-	spawn_cost = 2000 //was 2, we aren't using it now
+	spawn_cost = 1
+	player_cost = 6 // Нынешнее значение основано на количестве игроков в авейке
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT
 	apc_test_exempt_areas = list(

--- a/maps/random_ruins/exoplanet_ruins/radshrine/radshrine.dm
+++ b/maps/random_ruins/exoplanet_ruins/radshrine/radshrine.dm
@@ -3,6 +3,6 @@
 	id = "radshrine"
 	description = "A small radioactive shrine dedicated to an anomaly."
 	suffixes = list("radshrine/radshrine.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS|TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT

--- a/maps/random_ruins/exoplanet_ruins/spider_nest/spider_nest.dm
+++ b/maps/random_ruins/exoplanet_ruins/spider_nest/spider_nest.dm
@@ -3,6 +3,6 @@
 	id = "spider_nest"
 	description = "A small buidling with a spider infestation."
 	suffixes = list("spider_nest/spider_nest.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS|TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN

--- a/maps/random_ruins/exoplanet_ruins/tar_anomaly/tar_anomaly.dm
+++ b/maps/random_ruins/exoplanet_ruins/tar_anomaly/tar_anomaly.dm
@@ -3,6 +3,6 @@
 	id = "tar_anomaly"
 	description = "An anomaly in the center of a ring of tar."
 	suffixes = list("tar_anomaly/tar_anomaly.dmm")
-	cost = 1
+	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS|TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_ALIEN

--- a/maps/random_ruins/space_ruins/space_ruins.dm
+++ b/maps/random_ruins/space_ruins/space_ruins.dm
@@ -2,11 +2,11 @@
 
 /datum/map_template/ruin/space
 	prefix = "maps/random_ruins/space_ruins/"
-	cost = 1
+	spawn_cost = 1
 
 /datum/map_template/ruin/space/multi_zas_test
 	name = "Multi-ZAS Test"
 	id = "multi_zas_test"
 	description = "if this has vacuum in it, that's not good!"
 	suffixes = list("multi_zas_test.dmm")
-	cost = 1
+	spawn_cost = 1

--- a/maps/sierra/sierra.dm
+++ b/maps/sierra/sierra.dm
@@ -148,6 +148,8 @@
 	#include "../away/meatstation/meatstation.dm"
 	#include "../away/miningstation/miningstation.dm"
 
+	#include "../random_ruins/exoplanet_ruins/playablecolony_inf/playablecolony.dm"
+
 	#define using_map_DATUM /datum/map/sierra
 
 #elif !defined(MAP_OVERRIDE)

--- a/maps/sierra/sierra_define.dm
+++ b/maps/sierra/sierra_define.dm
@@ -38,7 +38,7 @@
 	recommended_players = 20
 //	minimum_players = 0 its already 0
 
-	away_site_budget = 5
+	away_site_budget = 7.5
 	min_offmap_players = 10
 
 	id_hud_icons = 'maps/sierra/icons/assignment_hud.dmi'

--- a/maps/sierra/sierra_define.dm
+++ b/maps/sierra/sierra_define.dm
@@ -38,7 +38,7 @@
 	recommended_players = 20
 //	minimum_players = 0 its already 0
 
-	away_site_budget = 7.5
+	away_site_budget = 7.5 // Было 5, увеличили на 50% вместе с уменьешением цены для одноуровневых авеек ~bear1ake
 	min_offmap_players = 10
 
 	id_hud_icons = 'maps/sierra/icons/assignment_hud.dmi'

--- a/maps/sierra/sierra_define.dm
+++ b/maps/sierra/sierra_define.dm
@@ -39,6 +39,7 @@
 //	minimum_players = 0 its already 0
 
 	away_site_budget = 5
+	min_offmap_players = 10
 
 	id_hud_icons = 'maps/sierra/icons/assignment_hud.dmi'
 

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -53,4 +53,6 @@
 	recommended_players = 40
 
 	away_site_budget = 3
+	min_offmap_players = 12
+
 	id_hud_icons = 'maps/torch/icons/assignment_hud.dmi'

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -104,6 +104,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/num_exoplanets = 0
 	var/list/planet_size  //dimensions of planet zlevel, defaults to world size. Due to how maps are generated, must be (2^n+1) e.g. 17,33,65,129 etc. Map will just round up to those if set to anything other.
 	var/away_site_budget = 0
+	var/min_offmap_players = 0
 
 	var/playable = 0
 	var/recommended_players
@@ -274,6 +275,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		if ("local_currency_name") local_currency_name = value
 		if ("local_currency_name_singular") local_currency_name_singular = value
 		if ("local_currency_name_short") local_currency_name_short = value
+		if ("min_offmap_players") min_offmap_players = text2num_or_default(value, min_offmap_players)
 		else log_misc("Unknown setting [name] in [filename].")
 
 /datum/map/proc/setup_map()
@@ -296,17 +298,21 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 
 /* It is perfectly possible to create loops with TEMPLATE_FLAG_ALLOW_DUPLICATES and force/allow. Don't. */
 /proc/resolve_site_selection(datum/map_template/ruin/away_site/site, list/selected, list/available, list/unavailable, list/by_type)
-	var/cost = 0
+	var/spawn_cost = 0
+	var/player_cost = 0
 	if (site in selected)
 		if (!(site.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
-			return cost
+			return list(spawn_cost, player_cost)
 	if (!(site.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
 		available -= site
-	cost += site.cost
+	spawn_cost += site.spawn_cost
+	player_cost += site.player_cost
 	selected += site
 
 	for (var/forced_type in site.force_ruins)
-		cost += resolve_site_selection(by_type[forced_type], selected, available, unavailable, by_type)
+		var/list/costs = resolve_site_selection(by_type[forced_type], selected, available, unavailable, by_type)
+		spawn_cost += costs[1]
+		player_cost += costs[2]
 
 	for (var/banned_type in site.ban_ruins)
 		var/datum/map_template/ruin/away_site/banned = by_type[banned_type]
@@ -326,7 +332,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 				continue
 		available[allowed] = allowed.spawn_weight
 
-	return cost
+	return list(spawn_cost, player_cost)
 
 
 /datum/map/proc/build_away_sites()
@@ -356,19 +362,27 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 			available[site] = round(site.spawn_weight * 100) // INF, было available[site] = site.spawn_weight
 		by_type[site.type] = site
 
-	var/budget = away_site_budget
-	for (var/datum/map_template/ruin/away_site/site in guaranteed)
-		budget -= resolve_site_selection(site, selected, available, unavailable, by_type)
+	var/points = away_site_budget
+	var/players = -min_offmap_players
+	for (var/client/C)
+		++players
 
-	while (budget > 0 && length(available))
+	for (var/datum/map_template/ruin/away_site/site in guaranteed)
+		var/list/costs = resolve_site_selection(site, selected, available, unavailable, by_type)
+		points -= costs[1]
+		players -= costs[2]
+
+	while (points > 0 && length(available))
 		var/datum/map_template/ruin/away_site/site = pickweight(available)
-		if (site.cost > budget)
+		if (site.spawn_cost && site.spawn_cost > points || site.player_cost && site.player_cost > players)
 			unavailable += site
 			available -= site
 			continue
-		budget -= resolve_site_selection(site, selected, available, unavailable, by_type)
+		var/list/costs = resolve_site_selection(site, selected, available, unavailable, by_type)
+		points -= costs[1]
+		players -= costs[2]
 
-	report_progress("Finished selecting away sites ([english_list(selected)]) for [away_site_budget - budget] cost of [away_site_budget] budget.")
+	report_progress("Finished selecting away sites ([english_list(selected)]) for [away_site_budget - points] cost of [away_site_budget] budget.")
 
 	for (var/datum/map_template/template in selected)
 		if (template.load_new_z())

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -366,6 +366,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/players = -min_offmap_players
 	for (var/client/C)
 		++players
+	var/players_budget = players // INF, для логирования ~bear1ake
 
 	for (var/datum/map_template/ruin/away_site/site in guaranteed)
 		var/list/costs = resolve_site_selection(site, selected, available, unavailable, by_type)
@@ -382,7 +383,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		points -= costs[1]
 		players -= costs[2]
 
-	report_progress("Finished selecting away sites ([english_list(selected)]) for [away_site_budget - points] cost of [away_site_budget] budget.")
+	report_progress("Finished selecting away sites ([english_list(selected)]) for [away_site_budget - points] cost of [away_site_budget] spawn and [players_budget] players budget.") // INF, было report_progress("Finished selecting away sites ([english_list(selected)]) for [away_site_budget - points] cost of [away_site_budget] budget.") 
 
 	for (var/datum/map_template/template in selected)
 		if (template.load_new_z())

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -383,7 +383,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		points -= costs[1]
 		players -= costs[2]
 
-	report_progress("Finished selecting away sites ([english_list(selected)]) for [away_site_budget - points] cost of [away_site_budget] spawn and [players_budget] players budget.") // INF, было report_progress("Finished selecting away sites ([english_list(selected)]) for [away_site_budget - points] cost of [away_site_budget] budget.") 
+	report_progress("Finished selecting away sites ([english_list(selected)]) for [away_site_budget - points] cost of [away_site_budget] spawn and [players] of [players_budget] players budget.") // INF, было report_progress("Finished selecting away sites ([english_list(selected)]) for [away_site_budget - points] cost of [away_site_budget] budget.") 
 
 	for (var/datum/map_template/template in selected)
 		if (template.load_new_z())


### PR DESCRIPTION
Очки карт остались прежними, очки игроков приравнены к количеству слотов, которые имеются на авейке.
by Spookerton

Добавлено оповещение для авейтеров

Возвращена колония

## Changelog
:cl: bear1ake & Laxesh ft. Spookerton & quardbreak
rscadd: Спавн away-локаций (далее авейки) теперь учитывает онлайн на момент инициализации мастер-контроллера на сервере. Считайте, прямо на старте сервера.
rscadd: Добавлено оповещение о близком конце раунда для дискорд-сервера.
rscadd: Возвращена играбельная колония.
tweak: Бюджет авеек для Сьерры повышен до 7.5 очков. Наслаждайтесь наводнением авеек в небольшой онлайн.
balance: Большая часть небольших не населенных авеек теперь имеет небольшую стоимость.
balance: Авейки с игроками имеют стоимость в игроках, сравнимую с их количеством слотов для входа в игру.
/:cl: