### PR TITLE
Теперь скреллы и таяры справедливо могут занимать должности СЕ и СМО.

### DIFF
--- a/html/changelogs_infinity/vasgen40k-210521-9477.yml
+++ b/html/changelogs_infinity/vasgen40k-210521-9477.yml
@@ -1,0 +1,14 @@
+# Your name.  
+author: vasgen40k
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Скреллы теперь могут занимать должность СМО."
+  - rscdel: "Таяры теперь могут занимать должности СМО и СЕ."

--- a/maps/sierra/job/jobs.dm
+++ b/maps/sierra/job/jobs.dm
@@ -16,8 +16,8 @@
 		/datum/species/unathi  		 = list(HUMAN_ONLY_JOBS/*, /datum/job/adjutant, /datum/job/senior_doctor, /datum/job/senior_scientist*/),
 		/datum/species/unathi/yeosa  = list(HUMAN_ONLY_JOBS/*, /datum/job/adjutant, /datum/job/senior_doctor, /datum/job/senior_scientist*/),
 		/datum/species/unathi/erosan = list(HUMAN_ONLY_JOBS/*, /datum/job/adjutant, /datum/job/senior_doctor, /datum/job/senior_scientist*/),
-		/datum/species/skrell  		 = list(/datum/job/captain, /datum/job/hos, /datum/job/hop, /*/datum/job/chief_engineer, /datum/job/rd, *//datum/job/cmo, /datum/job/iaa, /datum/job/psychiatrist),
-		/datum/species/tajaran 		 = list(HUMAN_ONLY_JOBS/*, /datum/job/senior_doctor*/),
+		/datum/species/skrell  		 = list(/datum/job/captain, /datum/job/hos, /datum/job/hop, /*/datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo, *//datum/job/iaa, /datum/job/psychiatrist),
+		/datum/species/tajaran 		 = list(/datum/job/captain, /datum/job/hos, /datum/job/hop, /*/datum/job/chief_engineer, /datum/job/cmo, *//datum/job/rd, /datum/job/iaa, /datum/job/psychiatrist),
 		/datum/species/machine 		 = list(/datum/job/captain, /datum/job/hos, /datum/job/security_assistant, /datum/job/psychiatrist),
 		/datum/species/resomi  		 = list(HUMAN_ONLY_JOBS, /datum/job/officer, /datum/job/exploration_leader,\
 									/datum/job/warden, /datum/job/security_assistant),


### PR DESCRIPTION
После небольшого обсуждения вопроса с главой ксенокома, мы пришли к мнению, что следующие должности вполне логично вернуть данным ксенорасам:

- Скреллам вернуть СМО
- Таярам вернуть СМО и СЕ.