### PR TITLE
Возврат платы платы телепорта и брони наёмникам. Мапперские поправки по базе наёмников. 

### DIFF
--- a/infinity/code/datums/uplink/armor.dm
+++ b/infinity/code/datums/uplink/armor.dm
@@ -7,13 +7,13 @@
 
 /datum/uplink_item/item/armor
 	category = /datum/uplink_category/armor
-/* 
+
 /datum/uplink_item/item/armor/heavy_armor
 	name = "Heavy Armor Vest and Helmet"
 	item_cost = 30
 	antag_costs = list(MODE_MERCENARY = 20)
-	path = /obj/item/storage/backpack/dufflebag/syndie_kit/armor
- */
+	path = /obj/item/storage/backpack/satchel/syndie_kit/armor
+
 /datum/uplink_item/item/armor/space_suit
 	name = "Space Combat Suit"
 	item_cost = 50

--- a/infinity/code/datums/uplink/devices and tools.dm
+++ b/infinity/code/datums/uplink/devices and tools.dm
@@ -78,3 +78,8 @@
 	desc = "The Constrictor Harness will compress your torso upon activation, allowing you to enter narrow spaces. Using the Constrictor Harness prevents you from moving properly. Carefully look into which pipe you climb!"
 	item_cost = 60
 	path = /obj/item/storage/backpack/satchel/syndie_kit/constrictor_harness
+
+/datum/uplink_item/item/tools/teleporter_circuit
+	name = "Teleporter Circuit Board"
+	item_cost = 40
+	path = /obj/item/stock_parts/circuitboard/teleporter

--- a/infinity/code/datums/uplink/devices and tools.dm
+++ b/infinity/code/datums/uplink/devices and tools.dm
@@ -82,4 +82,5 @@
 /datum/uplink_item/item/tools/teleporter_circuit
 	name = "Teleporter Circuit Board"
 	item_cost = 40
+	antag_roles = list(MODE_MERCENARY)
 	path = /obj/item/stock_parts/circuitboard/teleporter

--- a/maps/antag_spawn/mercenary/mercenary_base_inf.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base_inf.dmm
@@ -1374,8 +1374,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle/rear)
 "cj" = (
-/obj/machinery/atmospherics/valve/shutoff,
-/obj/effect/floor_decal/industrial/shutoff,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1396,6 +1394,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle/rear)
 "ck" = (
@@ -1766,6 +1765,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 6
 	},
+/obj/machinery/tele_pad,
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle/rear)
 "cO" = (


### PR DESCRIPTION
Описание
=======

После мержа у наёмников и предателей пропали следующие предметы: 

* Набор тяжёлой брони
* Плата для консоли телепорта

Данный пулл-реквест возвращает предметы обратно в аплинк. 

## Восстановление телепорта на Десперадо

После мержа конструкция телепорта изменилась из-за чего "рамка" телепорта исчезла с корабля наёмников "Десперадо". В виду того, что к подрывникам возвращается возможность купить плату консоли телепорта, на десперадо появляется телепорт-пад, благодаря которому наёмники смогут воспользоваться телепортацией для проникновения на объект.

Скриншоты ниже - телепорт на Десперадо до мержа и телепорт на Десперадо в пулл-реквесте.

![image](https://user-images.githubusercontent.com/22749671/119571641-42f74480-bdba-11eb-9659-b0e66127e0f9.png)
![image](https://user-images.githubusercontent.com/22749671/119571911-9d90a080-bdba-11eb-8995-6ded57ec08da.png)

## Исправление труб на Десперадо

На Десперадо была обнаружена следующая проблема: автоматическая заглушка трубы пыталась связаться одновременно с регулятором давления и синей трубой для подачи воздуха. Так как связующие были по сути "разными трубами", заглушка не могла нормально соединиться, поэтому сразу после заглушки следовал кусок несоединённой трубы, который выдавал себя громким шипением. Ситуация исправлена заменой заглушки на универсальный адаптер труб.

![image](https://user-images.githubusercontent.com/22749671/119572470-74bcdb00-bdbb-11eb-9e87-05f13d4b73bd.png)


## Changelog
:cl:
rscadd: Плата телепорта вернулась в аплинк наёмников. Ищите в разделе "Девайсы".
rscadd: Набор тяжёлой брони вернулся в аплинк наёмников и предателей. Ищите в разделе "Броня".
rscadd: На Десперадо наёмников появился недостающий элемент телепорта -  Телепорт-пад.
maptweak: Исправлен сегмент труб на Десперадо.
/:cl: