### PR TITLE
Большие изменения по карте

### DIFF
--- a/infinity/code/game/machinery/vending.dm
+++ b/infinity/code/game/machinery/vending.dm
@@ -263,3 +263,25 @@
 					/obj/item/clothing/under/stripper/mankini = 1)
 
 	contraband = list()
+
+/obj/machinery/vending/engivend
+	products = list(
+		/obj/item/device/flashlight = 3,
+		/obj/item/device/multitool = 3,
+		/obj/item/device/multitool/multimeter = 3,
+		/obj/item/device/geiger = 3,
+		/obj/item/device/scanner/gas = 3,
+		/obj/item/device/t_scanner = 3,
+		/obj/item/device/cable_painter = 2,
+		/obj/item/rpd = 2,
+		/obj/item/clamp = 4,
+		/obj/item/tape_roll = 6,
+		/obj/item/device/paint_sprayer = 2,
+		/obj/item/grenade/chem_grenade/metalfoam = 5
+	)
+	contraband = list(/obj/item/cell/potato = 5)
+	premium = list(
+		/obj/item/combitool = 1,
+		/obj/item/wrench/power = 1,
+		/obj/item/wirecutters/power = 1
+	)

--- a/maps/sierra/areas/multideck.dm
+++ b/maps/sierra/areas/multideck.dm
@@ -12,6 +12,7 @@
 	//first deck
 /area/bridge/hall/level_two
 	name = "Bridge - Hall - Upper"
+	req_access = list(access_sec_doors)
 	//second deck
 /area/bridge/hall/level_one
 	name = "Bridge - Hall - Lower"

--- a/maps/sierra/areas/sierra3.dm
+++ b/maps/sierra/areas/sierra3.dm
@@ -410,7 +410,7 @@
 /area/medical/sleeper
 	name = "First Deck - Infirmary - Emergency Treatment Center"
 	icon_state = "exam_room"
-	req_access = list(access_medical_equip)
+	req_access = list(list(access_medical_equip, access_field_med))
 
 /area/medical/surgery
 	name = "First Deck - Infirmary - Operating Theatre"

--- a/maps/sierra/job/access.dm
+++ b/maps/sierra/job/access.dm
@@ -110,6 +110,18 @@
 	desc = "Actor"
 	region = ACCESS_REGION_GENERAL
 
+/var/const/access_field_eng = "ACCESS_FIELD_ENG"//99
+/datum/access/field_eng
+	id = access_field_eng
+	desc = "Field Engineer"
+	region = ACCESS_REGION_RESEARCH
+
+/var/const/access_field_med = "ACCESS_FIELD_MED"//100
+/datum/access/field_med
+	id = access_field_med
+	desc = "Field Medic"
+	region = ACCESS_REGION_RESEARCH
+
 /************
 * NSV sierra *
 ************/

--- a/maps/sierra/job/jobs_engineering.dm
+++ b/maps/sierra/job/jobs_engineering.dm
@@ -117,7 +117,7 @@
 	ideal_character_age = 20
 	economic_power = 3
 
-	outfit_type = /decl/hierarchy/outfit/job/sierra/crew/engineering/engineer/maints
+	outfit_type = /decl/hierarchy/outfit/job/sierra/crew/engineering/engineer/trainee
 	allowed_branches = list(/datum/mil_branch/employee, /datum/mil_branch/contractor)
 	allowed_ranks = list(/datum/mil_rank/civ/nt, /datum/mil_rank/civ/contractor)
 
@@ -181,7 +181,7 @@
 	access = list(	access_maint_tunnels, access_network,
 			       	access_tech_storage, access_emergency_storage, access_tcomsat)
 	minimal_access = list()
-	
+
 /datum/job/infsys/get_description_blurb()
 	return "Вы когда-нибудь хотели стать человеком, который сутками сидит на попе смирно и начинает проявлять признаки бурной деятельности, когда всё идёт коту под хвост?\
 	Поздравляю, Вы приняты на должность информационного техника. Сидите на попе смирно, серфите NTNet, истерите, когда связь внезапно обрывается, становитесь главным Hackerman-ом этой смены."

--- a/maps/sierra/job/jobs_exploration.dm
+++ b/maps/sierra/job/jobs_exploration.dm
@@ -147,7 +147,7 @@
 						SKILL_WEAPONS = SKILL_EXPERT)
 	required_role = list("Exploration Leader", "Expeditionary Pilot")
 
-	access = list(	access_explorer, access_eva, access_emergency_storage, access_medical,
+	access = list(	access_explorer, access_eva, access_emergency_storage, access_field_med,
 					access_guppy_helm, access_expedition_shuttle, access_guppy, access_hangar)
 
 	minimal_access = list()
@@ -196,7 +196,7 @@
 						SKILL_WEAPONS      = SKILL_EXPERT)
 	required_role = list("Exploration Leader", "Expeditionary Pilot")
 
-	access = list(	access_explorer, access_eva, access_emergency_storage, access_engine,
+	access = list(	access_explorer, access_eva, access_emergency_storage, access_field_eng,
 	 				access_guppy_helm, access_expedition_shuttle, access_guppy, access_hangar)
 
 	minimal_access = list()

--- a/maps/sierra/job/outfits.dm
+++ b/maps/sierra/job/outfits.dm
@@ -176,6 +176,10 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 	shoes = /obj/item/clothing/shoes/brown
 	id_types = list(/obj/item/card/id/sierra/crew/engineering/comms)
 
+/decl/hierarchy/outfit/job/sierra/crew/engineering/engineer/trainee
+	name = OUTFIT_JOB_NAME("Engineer Trainee - Sierra")
+	id_types = list(/obj/item/card/id/sierra/crew/engineering/trainee)
+
 	////////////
 	//SECURITY//
 	////////////

--- a/maps/sierra/sierra-1.dmm
+++ b/maps/sierra/sierra-1.dmm
@@ -24143,6 +24143,7 @@
 	dir = 4
 	},
 /obj/structure/anomaly_container,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/storage)
 "MG" = (
@@ -24279,6 +24280,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/storage)
 "MS" = (
@@ -24394,6 +24396,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 10
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/storage)
 "Nd" = (
@@ -24404,6 +24407,7 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/storage)
 "Ne" = (
@@ -24414,6 +24418,7 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
 /obj/structure/stasis_cage,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/storage)
 "Nf" = (
@@ -24463,6 +24468,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 6
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/storage)
 "Nj" = (

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -520,8 +520,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/solar,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/fabricator,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "aaZ" = (
@@ -626,14 +626,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
 "abg" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
 /obj/item/device/radio/intercom{
 	pixel_y = 26
 	},
+/obj/machinery/vending/engivend,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "abh" = (
@@ -652,10 +649,8 @@
 /area/crew_quarters/heads/office/ce)
 "abi" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/steel,
-/obj/item/cell/high,
-/obj/item/cell/high,
-/obj/item/cell/high,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/cell_charger,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "abj" = (
@@ -792,21 +787,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/maintenance_equipstorage)
 "abw" = (
-/obj/structure/closet/crate,
-/obj/item/stock_parts/circuitboard/batteryrack,
-/obj/item/stock_parts/circuitboard/batteryrack,
-/obj/item/stock_parts/circuitboard/smes,
-/obj/item/stock_parts/circuitboard/smes,
-/obj/item/stock_parts/smes_coil/super_io,
-/obj/item/stock_parts/smes_coil/super_io,
-/obj/item/stock_parts/smes_coil/super_capacity,
-/obj/item/stock_parts/smes_coil/super_capacity,
-/obj/item/stock_parts/smes_coil,
-/obj/item/stock_parts/smes_coil,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/ladder_mobile,
+/obj/item/ladder_mobile,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "abx" = (
@@ -827,12 +814,13 @@
 /area/hydroponics)
 "aby" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/engineering/hardstorage)
-"abz" = (
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/stack/material/glass{
+	amount = 30
+	},
+/obj/item/stack/material/glass{
+	amount = 30
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "abA" = (
@@ -1023,8 +1011,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hydroponics)
 "acc" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/structure/closet/shipping_wall/filled{
+	pixel_x = -25;
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "acd" = (
@@ -1045,12 +1037,14 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/lounge_big)
 "ace" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/stack/material/plastic/fifty,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/stack/material/aluminium/fifty,
+/obj/structure/table/rack,
+/obj/item/stack/material/steel{
+	amount = 30
+	},
+/obj/item/stack/material/steel{
+	amount = 30
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "ach" = (
@@ -1087,15 +1081,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/stack/material/glass/phoronglass{
+	amount = 30
+	},
+/obj/item/stack/material/glass/phoronrglass{
+	amount = 20
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "acn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/stack/material/plastic/fifty{
+	amount = 30
 	},
-/obj/structure/dispenser,
+/obj/item/stack/material/aluminium{
+	amount = 30
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "aco" = (
@@ -1445,18 +1449,8 @@
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Hard Storage"
 	},
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/storage/briefcase/inflatable{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/item/storage/briefcase/inflatable{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/item/inflatable_dispenser,
+/obj/machinery/vending/parts,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "adi" = (
@@ -2810,25 +2804,8 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/engine_room)
 "afz" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/rig/eva/equipped,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/brigdoor/southleft{
-	autoset_access = 0;
-	name = "suit storage";
-	req_access = list("ACCESS_SENENG")
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/assist,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "afA" = (
@@ -3135,7 +3112,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/airlock/multi_tile/engineering{
 	dir = 8;
-	name = "Engineering Hard Storage";
+	name = "Main Warehouse";
 	req_access = newlist()
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -3285,12 +3262,13 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "ago" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/cell_charger,
-/obj/structure/table/steel,
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/steel_reinforced,
+/obj/item/cell/high,
+/obj/item/cell/high,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "agq" = (
@@ -4240,6 +4218,7 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
+/obj/machinery/door/window/brigdoor/southleft,
 /turf/simulated/floor/tiled/techfloor,
 /area/bridge/hall/level_one)
 "ahW" = (
@@ -5546,7 +5525,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/substation/seconddeck)
 "akw" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Hydroponics - Storage";
 	dir = 4
@@ -5564,6 +5542,7 @@
 /obj/effect/floor_decal/corner/green/bordercorner2{
 	dir = 10
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/hydroponics/storage)
 "akx" = (
@@ -6083,14 +6062,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
+/obj/machinery/vending/tool,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "alp" = (
@@ -8090,6 +8063,9 @@
 "aoU" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/obj/structure/closet/firecloset,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/bridge/hall/level_one)
 "aoV" = (
@@ -10797,12 +10773,6 @@
 /obj/random/junk,
 /turf/simulated/floor/wood/ebony,
 /area/maintenance/abandoned_common)
-"atK" = (
-/obj/machinery/vending/assist{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/storage/tech)
 "atL" = (
 /obj/item/inflatable_duck,
 /obj/machinery/alarm{
@@ -10986,9 +10956,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/random/date_based/christmas/xmaslights{
 	dir = 8
 	},
@@ -10996,6 +10963,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engineering_monitoring)
@@ -11016,7 +10986,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/multi_tile/engineering{
-	name = "Engineering Hard Storage";
+	name = "Main Warehouse";
 	req_access = newlist()
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -11156,6 +11126,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled,
 /area/holocontrol)
 "auq" = (
@@ -12270,6 +12242,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
 "awg" = (
@@ -12318,8 +12293,8 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "awn" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/dispenser,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "awo" = (
@@ -12918,7 +12893,6 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
 	},
@@ -12928,10 +12902,11 @@
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/corner/yellow/bordercorner2{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/engineering_sierra/junior,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "axq" = (
@@ -13050,6 +13025,7 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
+/obj/machinery/door/window/brigdoor/southright,
 /turf/simulated/floor/tiled/techfloor,
 /area/bridge/hall/level_one)
 "axA" = (
@@ -13430,8 +13406,8 @@
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 2;
-	id_tag = "eng_res_storage";
-	name = "Materials Storage"
+	id_tag = "eng_QAW";
+	name = "Quick Access Warehouse"
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
@@ -13491,8 +13467,8 @@
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 2;
-	id_tag = "eng_res_storage";
-	name = "Materials Storage"
+	id_tag = "eng_QAW";
+	name = "Quick Access Warehouse"
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
@@ -13635,7 +13611,6 @@
 /area/engineering/engine_room)
 "ayw" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass/engineering{
 	name = "Equipment"
 	},
@@ -13643,6 +13618,7 @@
 /obj/random/date_based/christmas/doorwreath{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "ayx" = (
@@ -14216,11 +14192,11 @@
 	},
 /obj/machinery/button/blast_door{
 	desc = "A remote control-switch for shutters.";
-	id_tag = "eng_res_storage";
+	id_tag = "eng_QAW";
 	name = "Shutters Control";
 	pixel_x = -22;
 	pixel_y = 28;
-	req_access = list("ACCESS_EVA")
+	req_access = list("ACCESS_ENGINEERING")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/materials_storage)
@@ -14420,10 +14396,6 @@
 /area/engineering/locker_room)
 "azA" = (
 /obj/structure/table/steel,
-/obj/item/book/manual/engineering_hacking,
-/obj/item/book/manual/engineering_construction,
-/obj/item/book/manual/engineering_guide,
-/obj/item/book/manual/atmospipes,
 /obj/machinery/light_switch{
 	pixel_y = 29
 	},
@@ -14439,6 +14411,8 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner2{
 	dir = 4
 	},
+/obj/item/book/manual/engineering_hacking,
+/obj/item/book/manual/engineering_guide,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "azB" = (
@@ -14556,13 +14530,14 @@
 /obj/item/modular_computer/telescreen/preset/engineering{
 	pixel_y = 26
 	},
-/obj/item/storage/box/lights/mixed,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
+/obj/item/book/manual/engineering_construction,
+/obj/item/book/manual/atmospipes,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "azL" = (
@@ -14671,11 +14646,6 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner2{
 	dir = 1
 	},
-/obj/item/storage/box/lights/xenon,
-/obj/item/device/radio/off,
-/obj/item/device/radio/off,
-/obj/item/device/radio/off,
-/obj/item/device/radio/off,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "azS" = (
@@ -14773,18 +14743,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/stack/material/glass/phoronrglass{
-	amount = 20
-	},
-/obj/item/stack/material/glass/phoronrglass{
-	amount = 20
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/stack/material/glass/phoronglass{
-	amount = 50
+/obj/structure/table/rack,
+/obj/item/stack/material/plasteel{
+	amount = 20
+	},
+/obj/item/stack/material/plasteel{
+	amount = 20
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
@@ -15081,10 +15046,6 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/obj/item/tank/emergency/oxygen/double,
-/obj/item/tank/emergency/oxygen/double,
-/obj/item/tank/emergency/oxygen/double,
-/obj/item/tank/emergency/oxygen/double,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -15105,6 +15066,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_eva)
 "aAF" = (
@@ -15581,7 +15544,6 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "aBA" = (
-/obj/structure/closet/secure_closet/engineering_welding,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -24
@@ -15598,6 +15560,7 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner2{
 	dir = 10
 	},
+/obj/structure/closet/secure_closet/engineering_sierra/junior,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
@@ -15664,11 +15627,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "aBH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/seconddeck/aftport)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/locker_room)
 "aBI" = (
 /obj/machinery/computer/modular/preset/dock,
 /obj/effect/floor_decal/corner/blue/mono,
@@ -15899,21 +15862,6 @@
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftstarboard)
-"aCc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/seconddeck/aftport)
 "aCd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16055,12 +16003,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftport)
 "aCp" = (
@@ -16079,7 +16027,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "aCq" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -16091,6 +16038,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftport)
 "aCr" = (
@@ -18225,7 +18173,7 @@
 	},
 /obj/machinery/door/airlock/engineering/striped{
 	dir = 4;
-	name = "Materials Storage"
+	name = "Quick Access Warehouse"
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
@@ -19282,30 +19230,8 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/obj/item/stack/material/plasteel{
-	amount = 10
-	},
-/obj/item/stack/material/plasteel{
-	amount = 10
-	},
-/obj/item/stack/material/plasteel{
-	amount = 10
-	},
-/obj/item/stack/material/plasteel{
-	amount = 10
-	},
-/obj/item/stack/material/ocp/fifty,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light/small,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/northleft{
-	name = "Materials"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/materials_storage)
 "aIk" = (
@@ -19887,7 +19813,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "aJg" = (
-/obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
@@ -19899,6 +19824,10 @@
 	c_tag = "Engineering - EVA";
 	dir = 8
 	},
+/obj/structure/table/rack,
+/obj/item/inflatable_dispenser,
+/obj/item/storage/briefcase/inflatable,
+/obj/item/storage/briefcase/inflatable,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_eva)
 "aJh" = (
@@ -20524,34 +20453,10 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Resources";
 	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/northright{
-	name = "Materials"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/materials_storage)
@@ -20616,34 +20521,7 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 50
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 50
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 50
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 50
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/northleft{
-	name = "Materials"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/materials_storage)
 "aKG" = (
@@ -20842,32 +20720,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
-"aKV" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/stack/material/rods{
-	amount = 50
-	},
-/obj/item/stack/material/rods{
-	amount = 50
-	},
-/obj/item/stack/material/rods{
-	amount = 50
-	},
-/obj/item/stack/material/rods{
-	amount = 50
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light/small,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/northright{
-	name = "Materials"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/engineering/materials_storage)
 "aKW" = (
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/sleep/bunk_big/room_two)
@@ -21280,13 +21132,15 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/storage/tech)
 "aLL" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/open,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/water_cell)
 "aLM" = (
 /obj/structure/bed/chair/comfy/brown{
@@ -21428,9 +21282,6 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner2{
 	dir = 8
 	},
-/obj/machinery/vending/parts{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
@@ -21443,6 +21294,8 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner2{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "aMa" = (
@@ -21471,11 +21324,10 @@
 /obj/structure/sign/poster{
 	pixel_y = -32
 	},
-/obj/machinery/vending/engivend{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "aMe" = (
@@ -21924,11 +21776,10 @@
 /turf/simulated/floor/reinforced/n20,
 /area/engineering/atmos)
 "aMU" = (
-/obj/machinery/vending/tool{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
+/obj/machinery/photocopier,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "aMV" = (
@@ -22023,9 +21874,16 @@
 /area/engineering/atmos)
 "aNa" = (
 /obj/machinery/light,
-/obj/machinery/fabricator,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 9
+	},
+/obj/machinery/papershredder,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "aNb" = (
@@ -22156,12 +22014,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "aNk" = (
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "aNl" = (
@@ -22548,8 +22402,6 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "aNX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -23740,7 +23592,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/airlock/engineering/striped{
 	dir = 4;
-	name = "Materials Storage"
+	name = "Quick Access Warehouse"
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -23872,6 +23724,16 @@
 	dir = 8;
 	pixel_x = 20
 	},
+/obj/item/stock_parts/circuitboard/batteryrack,
+/obj/item/stock_parts/circuitboard/batteryrack,
+/obj/item/stock_parts/circuitboard/smes,
+/obj/item/stock_parts/circuitboard/smes,
+/obj/item/stock_parts/smes_coil/super_io,
+/obj/item/stock_parts/smes_coil/super_io,
+/obj/item/stock_parts/smes_coil/super_capacity,
+/obj/item/stock_parts/smes_coil/super_capacity,
+/obj/item/stock_parts/smes_coil,
+/obj/item/stock_parts/smes_coil,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/storage/tech)
 "aQA" = (
@@ -23890,32 +23752,13 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/seconddeck/fore)
 "aQB" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_y = -22
-	},
-/obj/structure/holoplant,
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/yellow/bordercorner2{
-	dir = 9
-	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "aQC" = (
@@ -25136,19 +24979,21 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/level1)
 "aTb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
 	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/yellow/bordercorner2,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "aTc" = (
@@ -26867,7 +26712,6 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 6
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
 /obj/effect/floor_decal/corner/yellow/bordercorner2,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_grid,
@@ -27837,14 +27681,6 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/obj/item/storage/briefcase/inflatable{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/item/storage/briefcase/inflatable{
-	pixel_x = 3;
-	pixel_y = 6
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -20
@@ -27856,6 +27692,20 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = null
+	},
+/obj/item/rig/eva/equipped,
+/obj/machinery/door/window/brigdoor/southleft{
+	autoset_access = 0;
+	dir = 4;
+	req_access = list(access_seneng)
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_eva)
 "aXG" = (
@@ -29563,12 +29413,8 @@
 	anchored = 1;
 	name = "anchored emergency closet"
 	},
-/obj/effect/floor_decal/spline/fancy/wood,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/green/border{
-	dir = 8
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
 	},
 /turf/simulated/floor/wood/mahogany,
 /area/crew_quarters/lounge_big)
@@ -31859,7 +31705,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/holoplant,
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/papershredder,
@@ -31997,10 +31842,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/engineering/bluespace/chamber)
-"bfQ" = (
-/obj/effect/floor_decal/corner/blue/mono,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/nano)
 "bfR" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/door/firedoor,
@@ -32147,23 +31988,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/foreport)
 "bgg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id_tag = "eng_lockdown";
-	name = "Engineering Lockdown"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/door/airlock/hatch/maintenance,
-/obj/effect/floor_decal/techfloor{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/steel_grid,
 /area/engineering/locker_room)
 "bgh" = (
 /obj/structure/barrier{
@@ -32329,9 +32160,9 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/engine_eva)
 "bgv" = (
-/obj/structure/table/rack,
-/obj/random/maintenance,
-/obj/random/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftport)
 "bgw" = (
@@ -32433,6 +32264,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/item/storage/slide_projector,
 /turf/simulated/floor/lino,
 /area/bridge/meeting_room)
 "bgJ" = (
@@ -32496,33 +32328,39 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/forestarboard)
 "bgO" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftport)
 "bgP" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftport)
 "bgQ" = (
@@ -34074,6 +33912,20 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo/south)
+"cap" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/locker_room)
 "ccS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -34792,6 +34644,17 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/crew_quarters/galley/backroom)
+"exH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/seconddeck/aftport)
 "ezl" = (
 /obj/machinery/floodlight,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -35033,12 +34896,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
-"fod" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/engineering/locker_room)
 "fop" = (
 /obj/machinery/door/airlock/civilian{
 	dir = 4;
@@ -35198,16 +35055,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/green/bordercorner{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge_big)
@@ -35467,7 +35321,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/airlock/engineering/striped{
-	name = "Materials Storage"
+	name = "Quick Access Warehouse"
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
@@ -35604,8 +35458,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "hzF" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/green/border,
+/obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge_big)
 "hEA" = (
@@ -36186,6 +36039,9 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/cafe)
+"jGB" = (
+/turf/simulated/floor/reinforced/nitrogen,
+/area/engineering/atmos)
 "jHb" = (
 /obj/structure/flora/seaweed/glow,
 /mob/living/simple_animal/aquatic/fish{
@@ -37264,15 +37120,6 @@
 /obj/random/date_based/christmas/xmaslights,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"nzb" = (
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id_tag = "bridge_windows"
-	},
-/turf/simulated/wall/r_wall/hull,
-/area/bridge/nano)
 "nDI" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -37426,10 +37273,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
 "ohi" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/green/border{
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
 /turf/simulated/floor/wood/mahogany,
@@ -38941,6 +38785,17 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/engineering/gravitaional_generator)
+"sKX" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/xenobiology/water_cell)
 "sMI" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -39012,17 +38867,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
 "sTq" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/green/border,
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/machinery/vending/hotfood{
-	dir = 4
-	},
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck - Lounge Dorms";
 	dir = 4
+	},
+/obj/machinery/vending/coffee{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
 	},
 /turf/simulated/floor/wood/mahogany,
 /area/crew_quarters/lounge_big)
@@ -39269,6 +39122,25 @@
 "tEg" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo/south)
+"tEy" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id_tag = "eng_lockdown";
+	name = "Engineering Lockdown"
+	},
+/obj/machinery/door/airlock/hatch/maintenance,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/wall/r_wall/prepainted,
+/area/engineering/locker_room)
 "tGi" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -39441,6 +39313,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
+/obj/item/storage/box/lights/xenon,
 /turf/simulated/floor/tiled/techfloor,
 /area/janitor)
 "ulR" = (
@@ -39746,6 +39619,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head_big)
+"uUy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/seconddeck/aftport)
 "uVE" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -40111,6 +39999,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/head_big)
+"wsh" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/table/rack,
+/obj/item/stack/material/ocp{
+	amount = 30
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/hardstorage)
 "wsO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -40155,8 +40054,8 @@
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 1
 	},
-/obj/structure/filingcabinet/filingcabinet,
 /obj/effect/floor_decal/corner/blue,
+/obj/structure/table/glass,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/nano)
 "wQb" = (
@@ -40287,10 +40186,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/bridge/nano)
 "xgC" = (
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/green/bordercorner{
+/obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/mahogany,
@@ -45087,13 +44983,13 @@ aaK
 bjf
 bjf
 rws
-nzb
+rws
 bjf
 akU
 aBY
 aPm
 bjf
-nzb
+rws
 rws
 bjf
 bjf
@@ -45695,9 +45591,9 @@ bfY
 aex
 uCz
 bbH
-bfQ
+bfL
 bfM
-bfQ
+bfL
 bfS
 iHV
 bcB
@@ -61862,7 +61758,7 @@ nLf
 azv
 aBw
 aHo
-aKV
+aIj
 nLf
 ajB
 ajB
@@ -62466,7 +62362,7 @@ aue
 axa
 ayw
 azy
-fod
+aBH
 vkN
 aMd
 aMa
@@ -63073,13 +62969,13 @@ axl
 aQD
 azR
 wEB
-vkN
+bgg
 aNk
 aQB
-aMa
+tEy
 bgv
-bgv
-bgv
+uUy
+exH
 bgO
 aCP
 aCS
@@ -63275,13 +63171,13 @@ axm
 ayx
 qXN
 aIh
-aIh
+cap
 aNX
 aTb
-bgg
-aBH
-aCc
-aCd
+aMa
+aSX
+aSX
+aSX
 bgP
 aOT
 aOY
@@ -63481,8 +63377,8 @@ aDg
 aDg
 aVT
 aMa
-aSX
-aSX
+jGB
+jGB
 aSX
 aCo
 aDl
@@ -64679,8 +64575,8 @@ aht
 acW
 abg
 aqf
-abz
 acn
+wsh
 bfe
 aur
 aqC
@@ -65715,7 +65611,7 @@ aPq
 aVh
 aXk
 aLL
-aLL
+sKX
 aSU
 aSM
 aOv
@@ -67098,7 +66994,7 @@ aYP
 aTo
 aIo
 aTT
-atK
+aTT
 aUd
 aiV
 amX
@@ -67122,8 +67018,8 @@ auQ
 aAy
 aNl
 aNG
-aYk
-aYk
+aSX
+aSX
 aTi
 aYa
 bbU

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -32345,7 +32345,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftport)
 "bgP" = (

--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -608,7 +608,7 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/machinery/photocopier/faxmachine{
-	department = "Bridge"
+	department = "Captain's reserve fax"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -2892,7 +2892,7 @@
 /area/medical/backstorage)
 "afK" = (
 /turf/simulated/wall/prepainted,
-/area/medical/sleeper)
+/area/medical/backstorage)
 "afL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -4857,7 +4857,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white/monotile,
-/area/medical/sleeper)
+/area/medical/locker)
 "ajf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -8966,7 +8966,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled/white/monotile,
-/area/hallway/infirmary)
+/area/medical/sleeper)
 "apc" = (
 /obj/effect/floor_decal/floordetail/edgedrain,
 /obj/structure/cable/cyan{
@@ -10013,7 +10013,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
-/area/hallway/infirmary)
+/area/medical/sleeper)
 "aqJ" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 8
@@ -10633,7 +10633,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/infirmary)
+/area/medical/sleeper)
 "arW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32185,6 +32185,16 @@
 	name = "Telecoms Blast Door";
 	pixel_y = -20
 	},
+/obj/structure/table/rack,
+/obj/item/stock_parts/keyboard,
+/obj/item/stock_parts/keyboard,
+/obj/item/stock_parts/keyboard,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/power/apc/buildable,
+/obj/item/stock_parts/power/apc/buildable,
+/obj/item/stock_parts/power/apc/buildable,
 /turf/simulated/floor/tiled/techmaint,
 /area/tcommsat/storage)
 "aYh" = (
@@ -38546,12 +38556,13 @@
 /area/crew_quarters/heads/office/iaa)
 "dEW" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
-/obj/structure/bed/chair/padded/blue{
-	dir = 8
-	},
 /obj/random/date_based/christmas/xmaslights{
 	dir = 4
 	},
+/obj/machinery/sleeper/survival_pod{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/hallway/infirmary)
 "dGl" = (
@@ -40048,12 +40059,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/bed/chair/padded/blue{
-	dir = 8
-	},
 /obj/random/date_based/christmas/xmaslights{
 	dir = 4
 	},
+/obj/machinery/sleeper/survival_pod{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/monotile,
 /area/hallway/infirmary)
 "knM" = (
@@ -40320,7 +40332,9 @@
 	},
 /obj/machinery/power/smes/buildable/preset{
 	_fully_charged = 1;
+	_input_maxed = 1;
 	_input_on = 1;
+	_output_maxed = 1;
 	_output_on = 1
 	},
 /obj/structure/cable/yellow{
@@ -40620,7 +40634,9 @@
 	},
 /obj/machinery/power/smes/buildable/preset{
 	_fully_charged = 1;
+	_input_maxed = 1;
 	_input_on = 1;
+	_output_maxed = 1;
 	_output_on = 1
 	},
 /obj/structure/cable/yellow{
@@ -63970,8 +63986,8 @@ acX
 adP
 enY
 abu
-abu
-abu
+aeG
+aeG
 aeG
 afB
 alj
@@ -64174,7 +64190,7 @@ enY
 aeH
 afE
 afM
-afK
+abu
 akj
 alk
 amq
@@ -64578,7 +64594,7 @@ enY
 afC
 sqo
 afP
-afK
+abu
 akl
 all
 amx
@@ -64780,7 +64796,7 @@ enY
 afD
 sqo
 agk
-afK
+abu
 kRC
 alm
 xyk
@@ -64982,7 +64998,7 @@ enY
 amm
 alh
 agl
-afK
+abu
 hFe
 aln
 agD
@@ -65184,7 +65200,7 @@ enY
 abu
 afL
 abu
-afK
+abu
 ako
 aln
 aFo

--- a/maps/sierra/sierra_shuttles.dm
+++ b/maps/sierra/sierra_shuttles.dm
@@ -352,10 +352,10 @@ SIERRA_ESCAPE_POD(9)
 	for(var/area/A in shuttle_area)
 		for(var/obj/machinery/alarm/alarm in A)
 			if(alarm.req_access)
-				alarm.req_access = list(list(access_engine_equip, access_expedition_shuttle, access_atmospherics), access_engine)	//(Engine equip OR Charon OR Atmos) + Engineering
+				alarm.req_access = list(list(access_engine, access_field_eng))  // engineering OR field eng
 		for(var/obj/machinery/power/apc/apc in A)
 			if(apc.req_access)
-				apc.req_access = list(list(access_engine_equip, access_expedition_shuttle), access_engine)	//(Engine equip OR Charon) + Engineering
+				apc.req_access = list(list(access_engine, access_field_eng))  // engineering OR field eng
 
 /obj/effect/shuttle_landmark/sierra/hangar/exploration_shuttle
 	name = "Charon Hangar"

--- a/maps/sierra/structures/closets/armory.dm
+++ b/maps/sierra/structures/closets/armory.dm
@@ -5,8 +5,7 @@
 	name = "submachine gun guncabinet"
 
 /obj/structure/closet/secure_closet/guncabinet/sierra_armory/smg/WillContain()
-	return list(/obj/item/gun/projectile/automatic/nt41/armory = 2,
-				/obj/item/ammo_magazine/n10mm = 6)
+	return list(/obj/item/bikehorn = 2)
 
 /obj/structure/closet/secure_closet/guncabinet/sierra_armory/shotgun
 	name = "shotgun guncabinet"

--- a/maps/sierra/structures/closets/engineering.dm
+++ b/maps/sierra/structures/closets/engineering.dm
@@ -33,7 +33,8 @@
 		/obj/item/device/multitool/multimeter,
 		/obj/item/storage/box/secret_project_disks,
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/industrial, /obj/item/storage/backpack/satchel/eng)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/eng, /obj/item/storage/backpack/messenger/engi))
+		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/eng, /obj/item/storage/backpack/messenger/engi)),
+		/obj/item/device/radio
 	)
 
 /obj/structure/closet/secure_closet/engineering_senior
@@ -58,7 +59,8 @@
 		/obj/item/device/megaphone,
 		/obj/item/clothing/gloves/insulated,
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/industrial, /obj/item/storage/backpack/satchel/eng)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/eng, /obj/item/storage/backpack/messenger/engi))
+		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/eng, /obj/item/storage/backpack/messenger/engi)),
+		/obj/item/device/radio
 	)
 
 /obj/structure/closet/secure_closet/engineering_sierra
@@ -80,8 +82,30 @@
 		/obj/item/taperoll/atmos,
 		/obj/item/clothing/gloves/insulated,
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/industrial, /obj/item/storage/backpack/satchel/eng)),
-		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/eng, /obj/item/storage/backpack/messenger/engi))
+		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/eng, /obj/item/storage/backpack/messenger/engi)),
+		/obj/item/device/radio
 	)
+
+/obj/structure/closet/secure_closet/engineering_sierra/junior
+	name = " junior engineer's locker"
+	req_access = list(access_engine)
+	closet_appearance = /decl/closet_appearance/secure_closet/engineering
+
+/obj/structure/closet/secure_closet/engineering_sierra/junior/WillContain()
+	return list(
+		/obj/item/clothing/accessory/storage/brown_vest,
+		/obj/item/storage/belt/utility/full,
+		/obj/item/device/radio/headset/headset_eng,
+		/obj/item/device/radio/headset/headset_eng/alt,
+		/obj/item/clothing/suit/storage/hazardvest,
+		/obj/item/clothing/mask/gas/alt,
+		/obj/item/clothing/glasses/meson,
+		/obj/item/taperoll/engineering,
+		/obj/item/device/flashlight/upgraded,
+		/obj/item/taperoll/atmos,
+		/obj/item/clothing/gloves/insulated,
+		/obj/item/storage/backpack/satchel/eng,
+		/obj/item/device/radio)
 
 /obj/structure/closet/secure_closet/atmos_sierra
 	name = "atmospherics equipment locker"

--- a/maps/sierra/structures/closets/exploration.dm
+++ b/maps/sierra/structures/closets/exploration.dm
@@ -104,7 +104,7 @@
 
 /obj/structure/closet/secure_closet/explorer/medic
 	name = "field medic's locker"
-	req_access = list(access_explorer, list(access_el, access_medical))
+	req_access = list(access_explorer, list(access_el, access_field_med))
 
 /obj/structure/closet/secure_closet/explorer/medic/WillContain()
 	return list(
@@ -128,7 +128,7 @@
 
 /obj/structure/closet/secure_closet/explorer/engineer
 	name = "field engineer's locker"
-	req_access = list(access_explorer, list(access_el, access_engine))
+	req_access = list(access_explorer, list(access_el, access_field_eng))
 
 /obj/structure/closet/secure_closet/explorer/engineer/WillContain()
 	return list(


### PR DESCRIPTION
# Описание

Данный пулл-реквест направлен на работу с картой и взаимодействие игроков с ней. Что-то появилось, что-то исчезло, что-то просто изменилось. Список будет большим.

---

### Дормитории: Декали зелёного уголка заменены на другие.

Декали, которые используются для выделения зелёного уголка очень сильно выделяются и не вписываются в общую палитру помещения. Теперь угол не будет так ярко выделен.

### Дормитории: Автомат с отравленной едой заменён на автомат с кофе

Очень вероятно, что автомат с отравленной едой попал в общую зону по ошибке. Во избежание роста смертности лысых ассистентов и чайных трапов было решено заменить этот автомат на автомат с кофе.

![image](https://user-images.githubusercontent.com/22749671/121091282-6e365680-c7f2-11eb-8a6f-b8fda9c9e186.png)

---

### Мостик: Уничтожены стены под некоторыми окнами.

В ходе переработки мостика была допущена ошибка в виде стен, что появлялись пол некоторыми окнами мостика. Теперь этих стен более не должно быть.

### Мостик: Убраны голоцветы под машинерией.

Тоже самое, что и стены - голоцветов под машинерией на мостике быть не должно

### Мостик: Создано ограничение прохода для Службы Безопасности

Офицеры Брига получили доступ к помещению перед ядром ИИ. Однако доступ на мостик им остаётся закрыт за счёт прохода из укреплённого стекла.

![image](https://user-images.githubusercontent.com/22749671/121091779-37147500-c7f3-11eb-98ef-d54f03cdb4c8.png)

---

### Телекоммуникации: Добавлены дополнительные детали для сборки машинерии.

Имея при себе детали для восстановления серверов и реле, информационные техники, главный инженер и его верный старший инженер сталкивались с проблемой, что у них нет ключевых деталей машинерии - кнопки, экраны и тесла-линки.  Их запаса должно хватить для установки трёх машин, что вполне будет достаточно.

![image](https://user-images.githubusercontent.com/22749671/121092582-72637380-c7f4-11eb-8e3f-97a30e860dd1.png)

---

### Инженерный: Переработан склад, в котором находилась канистра форона.

Данное помещение совмещает в себе склад материалов и небольшую мастерскую, в которой у Инженеров ресурсы будут под рукой для быстрого создания чего-либо с помощью автолата или своими руками.


![image](https://user-images.githubusercontent.com/22749671/121094577-865ca480-c7f7-11eb-8858-b739c14390e3.png)

### Инженерный: Исправлен баг, из-за которого стажёры получали стартовую экипировку Инженеров.

Данный баг существует уже давно и связан он с тем, что для стажеров не была прописана уникальная экипировка, которая появлялась бы у них на спавне. Стажёры получали пресет формы реакторных техников, откуда в их руки попадала карточка инженеров. Теперь у стажёров будет свой пресет формы, в который входит карточка самих стажёров.

*Для справки: два года назад доступ стажёров был скорректирован. Им нельзя было посещать такие локации как реактор, атмос, бсд и иметь доступ к шкафам инженеров. Из-за этого бага ограничивался только воздух.*

### Инженерный: Добавлены шкафы для стажёров.

Добавление этих шкафов решает две проблемы:

* Инженер остаётся без экипировки, когда на смене участвует, например, 2 стажёра и 2 инженера, которые берут экипировку из доступных шкафчиков.
* Стажёры остаются без экипировки из-за того, что у них нет доступа.

![image](https://user-images.githubusercontent.com/22749671/121094976-2286ab80-c7f8-11eb-9b8b-386131bde2c5.png)

### Инженерный: Переработан склад ресурсов.

Данный склад теперь называется "Складом Быстрого Доступа" и его содержимое зависит только от самих инженеров: будет ли этот склад регулярно пустовать или же его полки займут сумки с материалами и другими инструментами для того, чтобы не пришлось наворачивать круги по всему отделу.

![image](https://user-images.githubusercontent.com/22749671/121095527-2666fd80-c7f9-11eb-9a9b-278341c6f165.png)

### Инженерный: Сокращены стартовые запасы ресурсов.

Имея при себе достаточно большие запасы ресурсов, инженеры могли буквально собрать новую палубу и сделать её вполне рабочей. Теперь на складе лежат следующие запасы материалов:

|    МАТЕРИАЛ | БЫЛО  | СТАЛО |
| ----------: | :---: | :---: |
|       Сталь |  250  |  60   |
|    Пласталь |  40   |  40   |
|      Стекло |  100  |  60   |
|    У-Стекло |  200  |  60   |
|   БС-Стекло |  50   |  30   |
| У-БС-Стекло |  40   |  20   |
|   Аллюминий |  50   |  30   |
|     Пластик |  50   |  30   |

Данная корректировка была сделана для увеличения ощущения нехватки ресурсов и увеличения спроса материалов у Карго.

### Инженерный: Переделано помещение со скафандрами.

Теперь в этом помещении находятся портативные охладители, кейсы с надувными стенами и ИКС Старшего Инженера. Более логичное место их хранения.

![image](https://user-images.githubusercontent.com/22749671/121097513-c40ffc00-c7fc-11eb-9577-5bcfe1ce5ba2.png)

### Инженерный: Хранилище Азота увеличено.

У Азота есть прекрасное волшебное свойство - заканчиваться. Расширение хранилища Азота позволит если не избавиться от проблемы, то отсрочить полное исчезновение запасов этого газа к концу смены.

![image](https://user-images.githubusercontent.com/22749671/121097486-b78ba380-c7fc-11eb-9be3-4b2e8189b978.png)

---

### Полевой Медик: Переработан доступ.

Полевой медик теряет "базовый" медицинский доступ, но имеет при себе возможность зайти в помещение с крио-капсулой для транспортировки раненых и помощи врачам.

### Полевой Инженер: Переработан доступ.

Полевой инженер теряет "базовый" инженерный доступ. Однако он всё ещё может работать с APC и Air Alarm-мами на Хароне.

---

### Медицинский отсек: Добавлены стазис-капсулы у входа в отдел.

Стазис-капсулы являются спасительным способом дождаться медиков и не уйти в мир иной. Однако у людей совсем нет возможности как-то выждать врачей из-за того, что все стазис-капсулы находятся далеко за шлюзами. Данные капсулы слегка увеличат шансы игроков дождаться пробуждения какого-нибудь медика.

![image](https://user-images.githubusercontent.com/22749671/121098860-73e66900-c7ff-11eb-933a-2757c56546ab.png)

---

### Факс: Исправлен баг с недолётом факсов на мостик.

Проблема была в том, что у Капитанского Факса был адрес "Мостик". который принимал на себя все сообщения с ЦК, отправленные конкретно на мостик.

---

### Арсенал: NT41 заменены на LDC-542

Управлением было отдано распоряжение о замене NT на другое оружие. Теперь в арсенале будет находиться LDC-542 в размере трёх штук. Дополнительные обоймы не входят в комплект.

![image](https://user-images.githubusercontent.com/22749671/121099740-118e6800-c801-11eb-808f-db63f9c422a6.png)

## Changelog

:cl:
rscadd: Телекоммуникации: Добавлены дополнительные детали для сборки машинерии.
maptweak: Дормитории: Декали зелёного уголка заменены на другие.
maptweak: Дормитории: Автомат с отравленной едой заменён на автомат с кофе
bugfix: Мостик: Уничтожены стены под некоторыми окнами.
bugfix: Мостик: Убраны голоцветы под машинерией.
maptweak: Мостик: Создано ограничение прохода для Службы Безопасности
maptweak: Инженерный: Переработан склад, в котором находилась канистра форона.
bugfix: Инженерный: Исправлен баг, из-за которого стажёры получали стартовую экипировку Инженеров.
rscadd: Инженерный: Добавлены шкафы для стажёров.
maptweak: Инженерный: Переработан склад ресурсов.
balance: Инженерный: Сокращены стартовые запасы ресурсов.
maptweak: Переделано помещение со скафандрами.
maptweak: Инженерный: Хранилище Азота увеличено.
tweak: Полевой Медик: Переработан доступ.
tweak: Полевой Инженер: Переработан доступ.
maptweak: Медицинский отсек: Добавлены стазис-капсулы у входа в отдел.
bugfix: Факс: Исправлен баг с недолётом факсов на мостик. 
/:cl:
