### PR TITLE
Техник на корабле СолГова теперь будет получать обычную форму инженеров 

### DIFF
--- a/maps/away_inf/sentinel/sentinel_crew.dm
+++ b/maps/away_inf/sentinel/sentinel_crew.dm
@@ -299,7 +299,7 @@
 
 /decl/hierarchy/outfit/job/patrol/engineer
 	name = PATROL_OUTFIT_JOB_NAME("Technician")
-	uniform = /obj/item/clothing/under/solgov/utility/fleet/engineering/away_solpatrol
+	uniform = /obj/item/clothing/under/rank/engineer/away_solpatrol
 	belt = /obj/item/storage/belt/holster/general/away_solpatrol
 	gloves = /obj/item/clothing/gloves/insulated/black
 

--- a/maps/away_inf/sentinel/sentinel_items.dm
+++ b/maps/away_inf/sentinel/sentinel_items.dm
@@ -60,7 +60,7 @@
 /obj/item/clothing/under/solgov/utility/fleet/officer/command/commander/away_solpatrol
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/fleet, /obj/item/clothing/accessory/solgov/specialty/pilot, /obj/item/clothing/accessory/solgov/rank/fleet/officer/o4, /obj/item/clothing/accessory/solgov/fleet_patch/fifth)
 
-/obj/item/clothing/under/solgov/utility/fleet/engineering/away_solpatrol
+/obj/item/clothing/under/rank/engineer/away_solpatrol
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/engineering/fleet, /obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e4, /obj/item/clothing/accessory/solgov/fleet_patch/fifth)
 
 /obj/item/clothing/under/solgov/utility/fleet/medical/away_solpatrol


### PR DESCRIPTION
Флотская форма (fleet coveralls) сломана и не отображается. Протестировать локально не получилось, так как не хватает игроков. Проверьте в раунде

## Changelog
:cl:
bugfix: Техник на корабле Солгова не будет спавнится голым, а будет получать форму
/:cl:
