### PR TITLE
bugfix robotics_fabricator

### DIFF
--- a/code/game/machinery/robotics_fabricator.dm
+++ b/code/game/machinery/robotics_fabricator.dm
@@ -20,14 +20,14 @@
 	var/speed = 1
 	var/mat_efficiency = 1
 	
-	/* [ORIG]
+/* [ORIG]
 	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
-	[/ORIG] */
+[/ORIG] */
 	
-	// [INF]
+// [INF]
 	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_TITANIUM = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
 	var/res_max_amount = 200000
-	// [/INF]
+// [/INF]
 
 	var/datum/research/files
 	var/list/datum/design/queue = list()
@@ -301,10 +301,10 @@
 		if(MATERIAL_STEEL)
 			mattype = /obj/item/stack/material/steel
 			
-		// [INF]	
+// [INF]	
 		if(MATERIAL_TITANIUM)
 			mattype = /obj/item/stack/material/titanium
-		// [/INF]
+// [/INF]
 		
 		if(MATERIAL_GLASS)
 			mattype = /obj/item/stack/material/glass

--- a/code/game/machinery/robotics_fabricator.dm
+++ b/code/game/machinery/robotics_fabricator.dm
@@ -19,8 +19,19 @@
 
 	var/speed = 1
 	var/mat_efficiency = 1
+	
+	/* [ORIG]
+	
+	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
+	
+	[/ORIG] */
+	
+	// [INF]
+	
 	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_TITANIUM = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
 	var/res_max_amount = 200000
+
+	// [/INF]
 
 	var/datum/research/files
 	var/list/datum/design/queue = list()
@@ -293,8 +304,14 @@
 	switch(material)
 		if(MATERIAL_STEEL)
 			mattype = /obj/item/stack/material/steel
+			
+		// [INF]	
+			
 		if(MATERIAL_TITANIUM)
 			mattype = /obj/item/stack/material/titanium
+		
+		// [/INF]
+		
 		if(MATERIAL_GLASS)
 			mattype = /obj/item/stack/material/glass
 		if(MATERIAL_ALUMINIUM)

--- a/code/game/machinery/robotics_fabricator.dm
+++ b/code/game/machinery/robotics_fabricator.dm
@@ -21,16 +21,12 @@
 	var/mat_efficiency = 1
 	
 	/* [ORIG]
-	
 	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
-	
 	[/ORIG] */
 	
 	// [INF]
-	
 	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_TITANIUM = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
 	var/res_max_amount = 200000
-
 	// [/INF]
 
 	var/datum/research/files
@@ -306,10 +302,8 @@
 			mattype = /obj/item/stack/material/steel
 			
 		// [INF]	
-			
 		if(MATERIAL_TITANIUM)
 			mattype = /obj/item/stack/material/titanium
-		
 		// [/INF]
 		
 		if(MATERIAL_GLASS)

--- a/code/game/machinery/robotics_fabricator.dm
+++ b/code/game/machinery/robotics_fabricator.dm
@@ -19,7 +19,7 @@
 
 	var/speed = 1
 	var/mat_efficiency = 1
-	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
+	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_TITANIUM = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
 	var/res_max_amount = 200000
 
 	var/datum/research/files
@@ -293,6 +293,8 @@
 	switch(material)
 		if(MATERIAL_STEEL)
 			mattype = /obj/item/stack/material/steel
+		if(MATERIAL_TITANIUM)
+			mattype = /obj/item/stack/material/titanium
 		if(MATERIAL_GLASS)
 			mattype = /obj/item/stack/material/glass
 		if(MATERIAL_ALUMINIUM)


### PR DESCRIPTION
раньше фабрикатор в роботике не принимал в себя материал (титан) но после включения пары строчек случилось следующее:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

## Changelog
🆑
bugfix: Фабрикатор теперь может принимать в себя листы титана.
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
