### PR TITLE
Меняем требование к заказу ящика NT41 с синего на красный

### DIFF
--- a/maps/sierra/datums/supplypacks/security.dm
+++ b/maps/sierra/datums/supplypacks/security.dm
@@ -71,7 +71,7 @@
 	contains = list(/obj/item/gun/projectile/automatic/nt41 = 2)
 	cost = 60
 	containername = "\improper Ballistic PDW crate"
-	security_level = SUPPLY_SECURITY_ELEVATED
+	security_level = SUPPLY_SECURITY_HIGH
 
 
 /decl/hierarchy/supply_pack/security/holster


### PR DESCRIPTION
# Описание

Данный ПР переносит заказ в карго на ящик NT41 из доступных в синий код заказов в доступные по красному коду заказы за счёт своей смертоносности.

## Changelog
:cl:
balance: Заказать в карго ящик НТ41 можно теперь только во время Красного Кода.
/:cl: