### PR TITLE
Вбиваем в голову лидера мерков код от системы самоуничтожения

### DIFF
--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -79,8 +79,8 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 		player.equip_to_slot_or_del(leader, slot_head)
 		var/obj/item/paper/roles_nuclear/paper = new(get_turf(player))
 		player.put_in_hands(paper)
-		var/obj/machinery/nuclearbomb/nuke = locate(/obj/machinery/nuclearbomb/station) in world
-		player.StoreMemory("<b>Код для активации устройства самоуничтожения Сьерры:</b> [nuke.r_code]", /decl/memory_options/system)
+		var/obj/machinery/nuclearbomb/nuke = locate(/obj/machinery/nuclearbomb/station) in SSmachines.machinery
+		player.StoreMemory("<b>Код для активации устройства самоуничтожения [GLOB.using_map.full_name]:</b> [nuke.r_code]", /decl/memory_options/system)
 	else
 		var/obj/item/device/radio/uplink/U = new(get_turf(player), player.mind, 0)
 		player.put_in_hands(U)

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -7,6 +7,9 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 	role_text_plural = "Mercenaries"
 	landmark_id = "Syndicate-Spawn"
 	leader_welcome_text = "You are the leader of the mercenary strikeforce; hail to the chief. Use :t to speak to your underlings."
+//	welcome_text = "To speak on the strike team's private channel use :t."  // ORIG
+
+// [INF]
 	welcome_text = "<hr><u>Работа должна быть выполнена, а те, кто согласен идти с вами через ад должны остаться \
 	в живых</u> - это первое, о чём вам стоило бы задуматься, когда Вы согласились на эту роль. Ваша работа \
 	состоит из выполнения специфичных заказов от <b>очень</b> серьезных людей - политические убийства, \
@@ -17,6 +20,8 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 	Доставьте их в качестве заложников на свою базу за минуту до того, как залитый кровью невинных корабль \
 	будет уничтожен ядерным огнём. <br>Используйте префикс ':t' для общения со своими через рацию.\
 	<br><b>Определитесь с главным и постарайтесь не прикончить друг друга ещё до начала операции.</b>"
+// [/INF]
+
 	flags = ANTAG_VOTABLE | ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER
 	antaghud_indicator = "hudoperative"
 
@@ -42,6 +47,7 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 		return 0
 	global_objectives = list()
 //INF	global_objectives |= new /datum/objective/nuclear
+// [INF]
 	var/datum/objective/nuclear/kidnap/K
 	K = new /datum/objective/nuclear/kidnap()
 	K.choose_target()
@@ -50,6 +56,7 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 	global_objectives |= new /datum/objective/nuclear/steal_AI //INF
 	global_objectives |= new /datum/objective/nuclear/researches //INF
 	global_objectives |= new /datum/objective/nuclear //INF
+// [/INF]
 	return 1
 
 /datum/antagonist/mercenary/equip(var/mob/living/carbon/human/player)
@@ -59,6 +66,12 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 	var/decl/hierarchy/outfit/mercenary = outfit_by_type(/decl/hierarchy/outfit/mercenary)
 	mercenary.equip(player)
 
+/* [ORIG]
+	var/obj/item/device/radio/uplink/U = new(get_turf(player), player.mind, DEFAULT_TELECRYSTAL_AMOUNT)
+	player.put_in_hands(U)
+[/ORIG] */
+
+// [INF] This is our merc equipment on spawn ~ SidVeld
 	if(player.mind == leader)
 		var/obj/item/device/radio/uplink/U = new(get_turf(player), player.mind, TEAM_TELECRYSTAL_AMOUNT)
 		player.put_in_hands(U)
@@ -66,11 +79,14 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 		player.equip_to_slot_or_del(leader, slot_head)
 		var/obj/item/paper/roles_nuclear/paper = new(get_turf(player))
 		player.put_in_hands(paper)
+		var/obj/machinery/nuclearbomb/nuke = locate(/obj/machinery/nuclearbomb/station) in world
+		player.StoreMemory("<b>Код для активации устройства самоуничтожения Сьерры:</b> [nuke.r_code]", /decl/memory_options/system)
 	else
 		var/obj/item/device/radio/uplink/U = new(get_turf(player), player.mind, 0)
 		player.put_in_hands(U)
 		var/obj/item/paper/roles_nuclear/paper = new(get_turf(player))
 		player.put_in_hands(paper)
+// [//INF]
 
 	return 1
 


### PR DESCRIPTION
# Описание

Недавно выяснилось, что у лидера наёмников плохая память, и когда команда уже собирается выполнять свою миссию, чтобы получить денюжки от ~~Зенг-ху~~ неизвестного заказчика, лидер в самый последний момент забывает код!

Данный пулл-реквест должен прописать таблетки лидеру наёмников и теперь при старте раунда он будет помнить код бомбы.

## Changelog
:cl:
bugfix: Наёмники: Лидер Наёмников снова знает код от бомбы. Чтобы узнать - используйте "Check Notes" во вкладке "IC"
/:cl: