### PR TITLE
Исправления кастомок + Фикс одежды Сентинеля

### DIFF
--- a/infinity/customs/asriel.dm
+++ b/infinity/customs/asriel.dm
@@ -33,7 +33,7 @@
 	trade_blacklisted = TRUE
 
 /obj/item/clothing/suit/armor/bulletproof/asriel
-	name = "rogue knight amor"
+	name = "rogue knight armor"
 	desc = "Nice suit."
 	icon = CUSTOM_ITEM_OBJ
 	item_icons = list(slot_wear_suit_str = CUSTOM_ITEM_MOB,

--- a/infinity/customs/wolforbykot.dm
+++ b/infinity/customs/wolforbykot.dm
@@ -109,6 +109,7 @@
 	item_icons = list(slot_w_uniform_str = CUSTOM_ITEM_MOB)
 	icon_state = "keganp"
 	item_state = "keganp"
+	on_rolled = list("rolled" = "keganp", "down" = "keganp")
 	trade_blacklisted = TRUE
 
 /obj/item/clothing/accessory/cloak/wolf

--- a/maps/away_inf/sentinel/sentinel_items.dm
+++ b/maps/away_inf/sentinel/sentinel_items.dm
@@ -54,20 +54,48 @@
  * ========
  */
 
+/obj/item/clothing/under/solgov/utility/fleet
+	name = "fleet coveralls"
+	desc = "The utility uniform of the SCG Fleet, made from an insulated material."
+	icon_state = "navyutility"
+	item_state = "navyutility"
+	worn_state = "navyutility"
+
 /obj/item/clothing/under/solgov/utility/fleet/officer/pilot1/away_solpatrol
-	starting_accessories = list(/obj/item/clothing/accessory/solgov/specialty/pilot, /obj/item/clothing/accessory/solgov/rank/fleet/officer, /obj/item/clothing/accessory/solgov/fleet_patch/fifth)
+	starting_accessories = list(
+		/obj/item/clothing/accessory/solgov/specialty/pilot,
+		/obj/item/clothing/accessory/solgov/rank/fleet/officer,
+		/obj/item/clothing/accessory/solgov/fleet_patch/fifth
+	)
 
 /obj/item/clothing/under/solgov/utility/fleet/officer/command/commander/away_solpatrol
-	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/fleet, /obj/item/clothing/accessory/solgov/specialty/pilot, /obj/item/clothing/accessory/solgov/rank/fleet/officer/o4, /obj/item/clothing/accessory/solgov/fleet_patch/fifth)
+	starting_accessories = list(
+		/obj/item/clothing/accessory/solgov/department/command/fleet,
+		/obj/item/clothing/accessory/solgov/specialty/pilot,
+		/obj/item/clothing/accessory/solgov/rank/fleet/officer/o4,
+		/obj/item/clothing/accessory/solgov/fleet_patch/fifth
+	)
 
 /obj/item/clothing/under/solgov/utility/fleet/engineering/away_solpatrol
-	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/engineering/fleet, /obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e4, /obj/item/clothing/accessory/solgov/fleet_patch/fifth)
+	starting_accessories = list(
+		/obj/item/clothing/accessory/solgov/department/engineering/fleet,
+		/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e4,
+		/obj/item/clothing/accessory/solgov/fleet_patch/fifth
+	)
 
 /obj/item/clothing/under/solgov/utility/fleet/medical/away_solpatrol
-	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/fleet, /obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e4, /obj/item/clothing/accessory/solgov/fleet_patch/fifth)
+	starting_accessories = list(
+		/obj/item/clothing/accessory/solgov/department/medical/fleet,
+		/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e4,
+		/obj/item/clothing/accessory/solgov/fleet_patch/fifth
+	)
 
 /obj/item/clothing/under/solgov/utility/fleet/away_solpatrol
-	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/fleet, /obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e4, /obj/item/clothing/accessory/solgov/fleet_patch/fifth)
+	starting_accessories = list(
+		/obj/item/clothing/accessory/solgov/department/command/fleet,
+		/obj/item/clothing/accessory/solgov/rank/fleet/enlisted/e4,
+		/obj/item/clothing/accessory/solgov/fleet_patch/fifth
+	)
 
 /obj/item/clothing/under/solgov/utility/army/urban/away_solpatrol
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/rank/army/enlisted/e5)
@@ -84,6 +112,3 @@
 /* MISC
  * ========
  */
-
-
-


### PR DESCRIPTION
# Описание

Данный пулл-реквест снова трогает кастомки, а также одежду Сентинеля.

* Кастомка Азриеля - исправлена опечатка
* Кастомка Вольфора и КО - разгрузка не будет исчезать при проке "roll down"
* Сентинель - утилити-униформа не теряет спрайты (Ту самую, что носят техники и медики)
