### PR TITLE
Исправления на Либерии

### DIFF
--- a/maps/away_inf/liberia/liberia.dm
+++ b/maps/away_inf/liberia/liberia.dm
@@ -4,6 +4,7 @@
 #include "liberia_jobs.dm"
 #include "liberia_shuttles.dm"
 #include "liberia_machinery.dm"
+#include "liberia_navpoints.dm"
 
 // Map template data.
 /datum/map_template/ruin/away_site/liberia //Основной файл
@@ -35,6 +36,12 @@
 	initial_restricted_waypoints = list(
 		"Mule" = list("nav_mule_start")
 	)
+	initial_generic_waypoints = list(
+		"nav_liberia_north",
+		"nav_liberia_east",
+		"nav_liberia_south",
+		"nav_liberia_west"
+	)
 
 /obj/effect/submap_landmark/joinable_submap/liberia
 	name = "Liberia"
@@ -46,5 +53,9 @@
 	_input_on = TRUE
 	_output_on = TRUE
 	_fully_charged = TRUE
+
+
+
+
 
 #undef WEBHOOK_SUBMAP_LOADED_LIBERIA

--- a/maps/away_inf/liberia/liberia.dmm
+++ b/maps/away_inf/liberia/liberia.dmm
@@ -3204,7 +3204,7 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/liberia/mule)
 "fm" = (
 /obj/structure/closet/crate/uranium,
@@ -3815,9 +3815,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/liberia/toiletroom1)
 "go" = (
-/obj/machinery/computer/shuttle_control/merchant{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
@@ -3830,6 +3827,7 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/blue,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/officeroom)
 "gp" = (
@@ -4453,6 +4451,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/liberia/personellroom2)
+"hu" = (
+/obj/effect/shuttle_landmark/nav_liberia/antag,
+/turf/space,
+/area/space)
 "hv" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4744,6 +4746,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/access_button/airlock_interior{
+	frequency = 1380;
+	master_tag = "liberia_solar_south";
+	name = "south liberia solar interior";
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/atmos)
 "id" = (
@@ -4906,14 +4914,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringstorage)
 "ix" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "solar_merchant_airlock";
-	name = "interior access button";
-	pixel_x = -24;
-	req_access = list("ACCESS_MERCHANT")
-	},
 /obj/machinery/power/solar_control/autostart{
 	dir = 4
 	},
@@ -5135,9 +5135,9 @@
 /obj/machinery/door/airlock/external{
 	autoset_access = 0;
 	frequency = 1380;
-	id_tag = "merchant_solar_outer";
+	id_tag = "liberia_solar_north_outer";
 	locked = 1;
-	name = "Solar External Access";
+	name = "North Liberia Solar External";
 	req_access = list("ACCESS_MERCHANT")
 	},
 /obj/structure/cable/yellow{
@@ -5148,27 +5148,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/engineeringstorage)
 "iU" = (
-/obj/structure/catwalk,
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "solar_merchant_sensor";
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 4;
-	id_tag = "solar_merchant_pump"
+	id_tag = "liberia_solar_north_pump"
 	},
+/obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
-	id_tag = "solar_merchant_airlock";
-	pixel_y = -24;
-	req_access = list("ACCESS_MERCHANT");
-	tag_airpump = "solar_merchant_pump";
-	tag_chamber_sensor = "solar_merchant_sensor";
-	tag_exterior_door = "solar_merchant_outer";
-	tag_interior_door = "solar_merchant_inner"
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -5176,6 +5161,24 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 1;
+	frequency = 1380;
+	id_tag = "liberia_solar_north";
+	name = "Liberia Solar North Airlock Controller";
+	pixel_y = -24;
+	req_access = list();
+	tag_airpump = "liberia_solar_north_pump";
+	tag_chamber_sensor = "liberia_solar_north_sensor";
+	tag_exterior_door = "liberia_solar_north_outer";
+	tag_interior_door = "liberia_solar_north_inner"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "liberia_solar_north_sensor";
+	master_tag = "liberia_solar_north";
+	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
 /area/liberia/engineeringstorage)
@@ -5187,14 +5190,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/merchantstorage)
 "iW" = (
-/obj/machinery/door/airlock/external{
-	autoset_access = 0;
-	frequency = 1380;
-	id_tag = "merchant_solar_inner";
-	locked = 1;
-	name = "Solar External Access";
-	req_access = list("ACCESS_MERCHANT")
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
@@ -5202,6 +5197,14 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	autoset_access = 0;
+	frequency = 1380;
+	id_tag = "liberia_solar_north_inner";
+	locked = 1;
+	name = "North Liberia Solar Interior";
+	req_access = list("ACCESS_MERCHANT")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/engineeringstorage)
@@ -5732,7 +5735,7 @@
 /obj/machinery/ion_engine{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/liberia/mule)
 "kg" = (
 /obj/machinery/door/airlock/civilian{
@@ -6239,10 +6242,6 @@
 /turf/simulated/floor/tiled/white,
 /area/liberia/medbay)
 "lb" = (
-/obj/structure/sign/warning/airlock{
-	dir = 1;
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
 	},
@@ -6260,6 +6259,12 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
+/obj/machinery/access_button/airlock_interior{
+	frequency = 1380;
+	master_tag = "liberia_solar_north";
+	name = "north liberia solar interior";
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringstorage)
 "lc" = (
@@ -6274,6 +6279,10 @@
 	},
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 1
+	},
+/obj/structure/sign/warning/airlock{
+	dir = 1;
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringstorage)
@@ -7086,6 +7095,10 @@
 /obj/item/stack/material/glass/fifty,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/merchantstorage)
+"qZ" = (
+/obj/effect/shuttle_landmark/nav_liberia/east,
+/turf/space,
+/area/space)
 "rc" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -7247,23 +7260,26 @@
 /obj/structure/catwalk,
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
-	id_tag = "solar_merchant_sensor";
+	id_tag = "liberia_solar_south_sensor";
+	master_tag = "liberia_solar_south";
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 4;
-	id_tag = "solar_merchant_pump"
+	id_tag = "liberia_solar_south_pump"
 	},
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 1;
 	frequency = 1380;
-	id_tag = "solar_merchant_airlock";
+	id_tag = "liberia_solar_south";
+	name = "Liberia Solar South Airlock Controller";
 	pixel_y = -24;
-	req_access = list("ACCESS_MERCHANT");
-	tag_airpump = "solar_merchant_pump";
-	tag_chamber_sensor = "solar_merchant_sensor";
-	tag_exterior_door = "solar_merchant_outer";
-	tag_interior_door = "solar_merchant_inner"
+	req_access = list();
+	tag_airpump = "liberia_solar_south_pump";
+	tag_chamber_sensor = "liberia_solar_south_sensor";
+	tag_exterior_door = "liberia_solar_south_outer";
+	tag_interior_door = "liberia_solar_south_inner"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -7384,6 +7400,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringstorage)
+"ue" = (
+/obj/machinery/access_button/airlock_exterior{
+	frequency = 1380;
+	master_tag = "liberia_solar_south";
+	name = "south liberia solars exterior";
+	step_x = -10
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/liberia/atmos)
 "uf" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/liberia/engineeringreactor)
@@ -7456,9 +7481,9 @@
 /obj/machinery/door/airlock/external{
 	autoset_access = 0;
 	frequency = 1380;
-	id_tag = "merchant_solar_inner";
+	id_tag = "liberia_solar_south_inner";
 	locked = 1;
-	name = "Solar External Access";
+	name = "South Liberia Solar Interior";
 	req_access = list("ACCESS_MERCHANT")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -7637,6 +7662,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/merchantstorage)
+"zj" = (
+/obj/effect/shuttle_landmark/nav_liberia/south,
+/turf/space,
+/area/space)
 "zl" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -7667,6 +7696,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/merchantstorage)
+"zU" = (
+/obj/effect/shuttle_landmark/nav_liberia/north,
+/turf/space,
+/area/space)
 "Aa" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/liberia/captain)
@@ -8148,7 +8181,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/liberia/merchantstorage)
 "Iw" = (
 /turf/simulated/wall/prepainted,
@@ -8202,9 +8235,9 @@
 /obj/machinery/door/airlock/external{
 	autoset_access = 0;
 	frequency = 1380;
-	id_tag = "merchant_solar_outer";
+	id_tag = "liberia_solar_south_outer";
 	locked = 1;
-	name = "Solar External Access";
+	name = "South Liberia Solar External";
 	req_access = list("ACCESS_MERCHANT")
 	},
 /obj/structure/cable/yellow{
@@ -8322,6 +8355,15 @@
 /area/liberia/bridge{
 	name = "Liberia - Bridge"
 	})
+"Lx" = (
+/obj/machinery/access_button/airlock_exterior{
+	frequency = 1380;
+	master_tag = "liberia_solar_north";
+	name = "north liberia solars exterior";
+	step_x = -10
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/liberia/engineeringstorage)
 "Lz" = (
 /turf/simulated/wall/prepainted,
 /area/liberia/toiletroom2)
@@ -8625,6 +8667,10 @@
 "QM" = (
 /turf/simulated/wall/prepainted,
 /area/liberia/guestroom2)
+"Ri" = (
+/obj/effect/shuttle_landmark/nav_liberia/west,
+/turf/space,
+/area/space)
 "Ro" = (
 /turf/simulated/floor/tiled/dark,
 /area/liberia/bridge{
@@ -17567,7 +17613,7 @@ aa
 aa
 aa
 aa
-aa
+Ri
 aa
 aa
 aa
@@ -26615,7 +26661,7 @@ aa
 aa
 aa
 aa
-aa
+zU
 aa
 aa
 aa
@@ -26849,7 +26895,7 @@ iy
 IA
 IA
 IA
-IA
+Lx
 iT
 ur
 aa
@@ -26867,7 +26913,7 @@ lh
 EG
 GP
 JE
-GP
+ue
 Uh
 lu
 lu
@@ -28111,7 +28157,7 @@ aa
 aa
 aa
 aa
-aa
+zj
 aa
 aa
 aa
@@ -37923,7 +37969,7 @@ aa
 aa
 aa
 aa
-aa
+hu
 aa
 aa
 aa
@@ -38576,7 +38622,7 @@ aa
 aa
 aa
 aa
-aa
+qZ
 aa
 aa
 aa

--- a/maps/away_inf/liberia/liberia.dmm
+++ b/maps/away_inf/liberia/liberia.dmm
@@ -7371,8 +7371,7 @@
 	frequency = 1380;
 	master_tag = "liberia_solar_north";
 	name = "north liberia solars exterior";
-	pixel_x = -10;
-	step_x = 0
+	pixel_x = -10
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/liberia/engineeringstorage)

--- a/maps/away_inf/liberia/liberia.dmm
+++ b/maps/away_inf/liberia/liberia.dmm
@@ -117,6 +117,10 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/merchantstorage)
+"ao" = (
+/obj/effect/shuttle_landmark/nav_liberia/south,
+/turf/space,
+/area/space)
 "aq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4451,10 +4455,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/liberia/personellroom2)
-"hu" = (
-/obj/effect/shuttle_landmark/nav_liberia/antag,
-/turf/space,
-/area/space)
 "hv" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -6732,6 +6732,10 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
+"mt" = (
+/obj/effect/shuttle_landmark/nav_liberia/west,
+/turf/space,
+/area/space)
 "mu" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -6847,6 +6851,10 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberia/library)
+"oo" = (
+/obj/effect/shuttle_landmark/nav_liberia/antag,
+/turf/space,
+/area/space)
 "op" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -7095,10 +7103,6 @@
 /obj/item/stack/material/glass/fifty,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/merchantstorage)
-"qZ" = (
-/obj/effect/shuttle_landmark/nav_liberia/east,
-/turf/space,
-/area/space)
 "rc" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -7362,6 +7366,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
+"tA" = (
+/obj/machinery/access_button/airlock_exterior{
+	frequency = 1380;
+	master_tag = "liberia_solar_north";
+	name = "north liberia solars exterior";
+	pixel_x = -10;
+	step_x = 0
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/liberia/engineeringstorage)
 "tI" = (
 /obj/effect/wallframe_spawn/reinforced/prepainted,
 /turf/simulated/floor/plating,
@@ -7400,15 +7414,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringstorage)
-"ue" = (
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1380;
-	master_tag = "liberia_solar_south";
-	name = "south liberia solars exterior";
-	step_x = -10
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/liberia/atmos)
 "uf" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/liberia/engineeringreactor)
@@ -7444,6 +7449,10 @@
 "ur" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/liberia/guestroom1)
+"uX" = (
+/obj/effect/shuttle_landmark/nav_liberia/north,
+/turf/space,
+/area/space)
 "vd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -7469,6 +7478,19 @@
 "vv" = (
 /turf/space,
 /area/liberia/solar1)
+"vw" = (
+/obj/effect/shuttle_landmark/nav_liberia/east,
+/turf/space,
+/area/space)
+"vB" = (
+/obj/machinery/access_button/airlock_exterior{
+	frequency = 1380;
+	master_tag = "liberia_solar_south";
+	name = "south liberia solars exterior";
+	pixel_x = -10
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/liberia/atmos)
 "vR" = (
 /obj/structure/cable/blue{
 	d1 = 1;
@@ -7662,10 +7684,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/merchantstorage)
-"zj" = (
-/obj/effect/shuttle_landmark/nav_liberia/south,
-/turf/space,
-/area/space)
 "zl" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -7696,10 +7714,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/merchantstorage)
-"zU" = (
-/obj/effect/shuttle_landmark/nav_liberia/north,
-/turf/space,
-/area/space)
 "Aa" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/liberia/captain)
@@ -8355,15 +8369,6 @@
 /area/liberia/bridge{
 	name = "Liberia - Bridge"
 	})
-"Lx" = (
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1380;
-	master_tag = "liberia_solar_north";
-	name = "north liberia solars exterior";
-	step_x = -10
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/liberia/engineeringstorage)
 "Lz" = (
 /turf/simulated/wall/prepainted,
 /area/liberia/toiletroom2)
@@ -8667,10 +8672,6 @@
 "QM" = (
 /turf/simulated/wall/prepainted,
 /area/liberia/guestroom2)
-"Ri" = (
-/obj/effect/shuttle_landmark/nav_liberia/west,
-/turf/space,
-/area/space)
 "Ro" = (
 /turf/simulated/floor/tiled/dark,
 /area/liberia/bridge{
@@ -17613,7 +17614,7 @@ aa
 aa
 aa
 aa
-Ri
+mt
 aa
 aa
 aa
@@ -26661,7 +26662,7 @@ aa
 aa
 aa
 aa
-zU
+uX
 aa
 aa
 aa
@@ -26895,7 +26896,7 @@ iy
 IA
 IA
 IA
-Lx
+tA
 iT
 ur
 aa
@@ -26913,7 +26914,7 @@ lh
 EG
 GP
 JE
-ue
+vB
 Uh
 lu
 lu
@@ -28157,7 +28158,7 @@ aa
 aa
 aa
 aa
-zj
+ao
 aa
 aa
 aa
@@ -37969,7 +37970,7 @@ aa
 aa
 aa
 aa
-hu
+oo
 aa
 aa
 aa
@@ -38622,7 +38623,7 @@ aa
 aa
 aa
 aa
-qZ
+vw
 aa
 aa
 aa

--- a/maps/away_inf/liberia/liberia_navpoints.dm
+++ b/maps/away_inf/liberia/liberia_navpoints.dm
@@ -1,0 +1,19 @@
+/obj/effect/shuttle_landmark/nav_liberia/north
+	name = "Liberia North"
+	landmark_tag = "nav_liberia_north"
+
+/obj/effect/shuttle_landmark/nav_liberia/east
+	name = "Liberia East"
+	landmark_tag = "nav_liberia_east"
+
+/obj/effect/shuttle_landmark/nav_liberia/south
+	name = "Liberia South"
+	landmark_tag = "nav_liberia_south"
+
+/obj/effect/shuttle_landmark/nav_liberia/west
+	name = "Liberia west"
+	landmark_tag = "nav_liberia_west"
+
+/obj/effect/shuttle_landmark/nav_liberia/antag
+	name = "Liberia North-East"
+	landmark_tag = "nav_liberia_antag"

--- a/maps/sierra/sierra_shuttles.dm
+++ b/maps/sierra/sierra_shuttles.dm
@@ -94,8 +94,9 @@ SIERRA_ESCAPE_POD(9)
 		"nav_casino_antag",
 		"nav_yacht_antag",
 		"nav_slavers_base_antag",
-		"nav_mining_antag"
-		)
+		"nav_mining_antag",
+		"nav_liberia_antag"
+	)
 
 /obj/effect/shuttle_landmark/ninja/deck1
 	name = "West of Fourth Deck"


### PR DESCRIPTION
# Описание

Данный пулл-реквест направлен на исправления на авей-карте "Либерия".  В основном ориентир был на один из последних репортов:

![image](https://user-images.githubusercontent.com/22749671/124736418-a9c25e80-df1f-11eb-8c90-c1ea1a43348d.png)

## Изменения

* Добавлено 5 новых нав-поинтов (4 точки для всех с каждой стороны света + 1 точка для ниндзи)

![image](https://user-images.githubusercontent.com/22749671/124736666-e68e5580-df1f-11eb-9765-a7794050b2ef.png)

* Кнопки и контроллеры на шлюзах у солнечных панелей исправлены и теперь могут быть дополнительными точками входа или выхода Либерии

![image](https://user-images.githubusercontent.com/22749671/124737203-66b4bb00-df20-11eb-9e8f-c8918fd56450.png)

* Бесполезная консоль  управления шаттлом в офисе торговцев заменена на стол

![image](https://user-images.githubusercontent.com/22749671/124737248-6fa58c80-df20-11eb-8949-e71ed11c4127.png)

* Пол под сенсорами Либерии заменён на тот, что имеет при себе воздух. Теперь Торговцам необходимо открывать створку для запуска сенсоров

![image](https://user-images.githubusercontent.com/22749671/124737277-77653100-df20-11eb-9af2-4baadbbc3938.png)

* Изменён пол под турбинами Мула. Теперь там изначально не будет находиться "пол с воздухом", что создавало ранее "активные углы"

![image](https://user-images.githubusercontent.com/22749671/124737341-86e47a00-df20-11eb-89d9-049d06cd5362.png)

## Changelog

:cl:
maptweak: Либерия: добавлено 5 новых нав-поинтов. 4 общих и 1 для антагониста.
maptweak: Либерия: Консоль управления шаттлом заменена на стол.
maptweak: Либерия: Кнопки и панель управления в шлюзовых сегментах у солнечных панелей переделаны.
maptweak: Либерия: Пол под сенсорами заменен на "безвоздушный".
maptweak: Либерия: Пол под турбинами Мула заменён на "безвоздушный".
/:cl:
