### PR TITLE
[Факел] Исправление военной униформы

### DIFF
--- a/maps/away_inf/sentinel/sentinel_items.dm
+++ b/maps/away_inf/sentinel/sentinel_items.dm
@@ -54,13 +54,6 @@
  * ========
  */
 
-/obj/item/clothing/under/solgov/utility/fleet
-	name = "fleet coveralls"
-	desc = "The utility uniform of the SCG Fleet, made from an insulated material."
-	icon_state = "navyutility"
-	item_state = "navyutility"
-	worn_state = "navyutility"
-
 /obj/item/clothing/under/solgov/utility/fleet/officer/pilot1/away_solpatrol
 	starting_accessories = list(
 		/obj/item/clothing/accessory/solgov/specialty/pilot,

--- a/maps/torch/items/clothing/solgov-under.dm
+++ b/maps/torch/items/clothing/solgov-under.dm
@@ -133,9 +133,9 @@
 /obj/item/clothing/under/solgov/utility/fleet
 	name = "fleet coveralls"
 	desc = "The utility uniform of the SCG Fleet, made from an insulated material."
-	icon_state = "navyutilityoff"
+	icon_state = "navyutility"
 	item_state = "jensensuit"
-	worn_state = "navyutilityoff"
+	worn_state = "navyutility"
 
 /obj/item/clothing/under/solgov/utility/fleet/command
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/fleet)
@@ -195,8 +195,8 @@
 /obj/item/clothing/under/solgov/utility/fleet/combat
 	name = "fleet fatigues"
 	desc = "Alternative utility uniform of the SCG Fleet, for when coveralls are impractical."
-	icon_state = "navyutilityoff"
-	worn_state = "navyutilityoff"
+	icon_state = "navyutility"
+	worn_state = "navyutility"
 
 /obj/item/clothing/under/solgov/utility/fleet/combat/security
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/security/fleet)


### PR DESCRIPTION
# Описание

Данный пулл-реквест должен исправить отображение военной униформы.

## В чём была проблема

Во время последних мержей были неверно переуказаны названия спрайтов униформы Флота
![image](https://user-images.githubusercontent.com/22749671/124740074-1a1eaf00-df23-11eb-9db0-5870f4ea112f.png)

Если заглянуть в файл, откуда берутся спрайты, то можно заметить, что названия у спрайтов действительно другие
![image](https://user-images.githubusercontent.com/22749671/124740990-f314ad00-df23-11eb-8799-0553bdcc465c.png)

А на Бее как раз указаны правильные названия используемых спрайтов
![image](https://user-images.githubusercontent.com/22749671/124740262-4a664d80-df23-11eb-8af0-2755d23cbb60.png)


## Changelog

:cl:
bugfix: Исправлено отображение спрайтов униформы Флота
/:cl:
