### PR TITLE
Добавление Science HUD для научного борга

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -90,3 +90,4 @@
 	. = ..()
 	hud = new /obj/item/clothing/glasses/hud/science(src)
 // [/INF]
+

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -75,8 +75,11 @@
 
 /obj/item/borg/sight/hud/jani/Initialize()
 	. = ..()
+/obj/item/borg/sight/hud/jani/Initialize()
+	. = ..()
 	hud = new /obj/item/clothing/glasses/hud/janitor(src)
 
+// [INF]
 /obj/item/borg/sight/hud/sci
 	name = "science hud"
 	icon_state = "scihud"
@@ -86,3 +89,4 @@
 /obj/item/borg/sight/hud/sci/Initialize()
 	. = ..()
 	hud = new /obj/item/clothing/glasses/hud/science(src)
+// [/INF]

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -76,3 +76,13 @@
 /obj/item/borg/sight/hud/jani/Initialize()
 	. = ..()
 	hud = new /obj/item/clothing/glasses/hud/janitor(src)
+
+/obj/item/borg/sight/hud/sci
+	name = "science hud"
+	icon_state = "scihud"
+	icon = 'icons/obj/clothing/obj_eyes.dmi'
+	hud_type = HUD_SCIENCE
+
+/obj/item/borg/sight/hud/sci/Initialize()
+	. = ..()
+	hud = new /obj/item/clothing/glasses/hud/science(src)

--- a/code/modules/mob/living/silicon/robot/modules/module_research.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_research.dm
@@ -27,7 +27,8 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/gripper/chemistry,
-		/obj/item/stack/nanopaste
+		/obj/item/stack/nanopaste,
+		/obj/item/borg/sight/hud/sci
 	)
 	synths = list(
 		/datum/matter_synth/nanite = 10000

--- a/code/modules/mob/living/silicon/robot/modules/module_research.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_research.dm
@@ -56,3 +56,4 @@
 	var/datum/matter_synth/nanite/nanite = locate() in synths
 	var/obj/item/stack/nanopaste/N = locate() in equipment
 	N.synths = list(nanite)
+

--- a/code/modules/mob/living/silicon/robot/modules/module_research.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_research.dm
@@ -28,7 +28,7 @@
 		/obj/item/reagent_containers/syringe,
 		/obj/item/gripper/chemistry,
 		/obj/item/stack/nanopaste,
-		/obj/item/borg/sight/hud/sci
+		/obj/item/borg/sight/hud/sci  // INF
 	)
 	synths = list(
 		/datum/matter_synth/nanite = 10000


### PR DESCRIPTION
# Описание

Добавил научному боргу научный худ для сканирования объектов на наличие технологий. До этого наличие технологий на борге можно было узнать только после разборки, что усложняет процесс исследований и делает реверс-инженеринг неэффективным.

![image](https://user-images.githubusercontent.com/65360018/126068299-7cfabe3e-5445-4b82-af1b-7d33f89113ec.png)

## Changelog

🆑
rscadd: Научному боргу добавлен специальный HUD учёных
/🆑


