### PR TITLE
Делаем раундстартовое пробуждение и пробуждение из крио менее раздражительным

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -492,7 +492,7 @@ SUBSYSTEM_DEF(jobs)
 			H.forceMove(truf)
 			var/obj/structure/bed/b = locate(/obj/structure/bed) in truf
 			if(istype(b) && !joined_late)
-				H.Sleeping(15)
+				H.Sleeping(3)
 				b.buckle_mob(H)
 		//[/INF]
 		else

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -135,8 +135,7 @@ GLOBAL_VAR(spawntypes)
 							sector = candidate
 					greetings = " на [istype(sector, /obj/effect/overmap/visitable/ship) ? "судне" : "станции"] '[GLOB.using_map.full_name]'."
 			to_chat(victim, SPAN_NOTICE("Вы пробуждаетесь от крио-сна[greetings]"))
-			victim.sleeping = 0
-			victim.Sleeping(rand(2,7))
+			victim.Sleeping(3)
 			victim.bodytemperature = victim.species.cold_level_1 //very cold, but a point before damage
 
 			if(!victim.isSynthetic()) //fluff. I didn't used else at next lines because of code readness
@@ -150,7 +149,6 @@ GLOBAL_VAR(spawntypes)
 				give_effect(victim)
 				give_advice(victim)
 
-				victim.drowsyness += 30
 //[/INF]
 			break//inf, was: return
 

--- a/infinity/code/datums/spawnpoints/cryo/effects.dm
+++ b/infinity/code/datums/spawnpoints/cryo/effects.dm
@@ -21,7 +21,7 @@
 		H.hydration = rand(0,200)
 		if(H.species.name == SPECIES_UNATHI)
 			H.nutrition = rand(100,200)
-	if(prob(15)) //stutterting and jittering (because of cold?)
+	if(prob(10)) //stutterting and jittering (because of cold?)
 		message += SPAN_WARNING("Трясет от холода. ")
 		H.make_jittery(120)
 		H.stuttering = 20


### PR DESCRIPTION
# Описание

Данный пулл-реквест направлен на сокращение времени ожидания игроков пробуждения их персонажей как во время старта игры так и во время позднего захода в игру. 

## Основные изменения

* Во время раундстартового пробуждения персонажи будут спать не 15, а 3 секунды.
* Во время пробуждения из крио глаза персонажа не будут покрываться пеленой, а скорость передвижения понижаться (не касается "особых" случаев пробуждения).
* Во время пробуждения из крио  персонажа не будет кидать в сон через несколько секунд после захода в раунд.
* Шанс заработать особый эффект пробуждения с описанием "Трясёт от холода." снижен до 10-ти процентов.
