### PR TITLE
Повышаем здоровье турелей.

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -20,8 +20,8 @@
 
 	var/raised = 0			//if the turret cover is "open" and the turret is raised
 	var/raising= 0			//if the turret is currently opening or closing its cover
-	var/health = 80			//the turret's health
-	var/maxhealth = 80		//turrets maximal health.
+	var/health = 500			//the turret's health
+	var/maxhealth = 500		//turrets maximal health.
 	var/auto_repair = 0		//if 1 the turret slowly repairs itself.
 	var/locked = 1			//if the turret's behaviour control access is locked
 	var/controllock = 0		//if the turret responds to control panels


### PR DESCRIPTION
Турели убивались с 2 выстрелов и по сути были бесполезны. Теперь потребуется потратить по больше сил для их убийства.
