### PR TITLE
"Сенсоры" синтам (Многоходовочка)

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -310,7 +310,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	name = "navigation console"
 	icon_keyboard = "generic_key"
 	icon_screen = "helm"
-    //Отключение ограничений на синтов
+//Отключение ограничений на синтов
 	//inf.exclude silicon_restriction = STATUS_UPDATE
 	machine_name = "navigation console"
 	machine_desc = "Used to view a sensor-assisted readout of the current sector and its surrounding areas."
@@ -326,7 +326,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	var/turf/T = get_turf(linked)
 	var/obj/effect/overmap/visitable/sector/current_sector = locate() in T
 	
-    //inf.exclude var/mob/living/silicon/silicon = user
+//inf.exclude var/mob/living/silicon/silicon = user
 	//inf.exclude data["viewing_silicon"] = ismachinerestricted(silicon)
 
 	data["sector"] = current_sector ? current_sector.name : "Deep Space"

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -311,7 +311,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	icon_keyboard = "generic_key"
 	icon_screen = "helm"
     //Отключение ограничений на синтов
-	//inf.exclude: silicon_restriction = STATUS_UPDATE
+	//inf.exclude silicon_restriction = STATUS_UPDATE
 	machine_name = "navigation console"
 	machine_desc = "Used to view a sensor-assisted readout of the current sector and its surrounding areas."
 
@@ -326,10 +326,8 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	var/turf/T = get_turf(linked)
 	var/obj/effect/overmap/visitable/sector/current_sector = locate() in T
 	
-	/* [inf.exclude]
-    var/mob/living/silicon/silicon = user
-	data["viewing_silicon"] = ismachinerestricted(silicon)
-    [/inf.exclude] */
+    //inf.exclude var/mob/living/silicon/silicon = user
+	//inf.exclude data["viewing_silicon"] = ismachinerestricted(silicon)
 
 	data["sector"] = current_sector ? current_sector.name : "Deep Space"
 	data["sector_info"] = current_sector ? current_sector.desc : "Not Available"

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -310,7 +310,6 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	name = "navigation console"
 	icon_keyboard = "generic_key"
 	icon_screen = "helm"
-	silicon_restriction = STATUS_UPDATE
 	machine_name = "navigation console"
 	machine_desc = "Used to view a sensor-assisted readout of the current sector and its surrounding areas."
 
@@ -324,9 +323,6 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 	var/turf/T = get_turf(linked)
 	var/obj/effect/overmap/visitable/sector/current_sector = locate() in T
-
-	var/mob/living/silicon/silicon = user
-	data["viewing_silicon"] = ismachinerestricted(silicon)
 
 	data["sector"] = current_sector ? current_sector.name : "Deep Space"
 	data["sector_info"] = current_sector ? current_sector.desc : "Not Available"

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -310,6 +310,8 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	name = "navigation console"
 	icon_keyboard = "generic_key"
 	icon_screen = "helm"
+    //Отключение ограничений на синтов
+	//inf.exclude: silicon_restriction = STATUS_UPDATE
 	machine_name = "navigation console"
 	machine_desc = "Used to view a sensor-assisted readout of the current sector and its surrounding areas."
 
@@ -323,6 +325,11 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 
 	var/turf/T = get_turf(linked)
 	var/obj/effect/overmap/visitable/sector/current_sector = locate() in T
+	
+	/* [inf.exclude]
+    var/mob/living/silicon/silicon = user
+	data["viewing_silicon"] = ismachinerestricted(silicon)
+    [/inf.exclude] */
 
 	data["sector"] = current_sector ? current_sector.name : "Deep Space"
 	data["sector_info"] = current_sector ? current_sector.desc : "Not Available"


### PR DESCRIPTION
Обычная консоль сенсоров слишком крута - но есть консоль навигации. Она не даёт расширенного вида и собственно бага с большим обзором на ИИ. Хоть через эту консоль нельзя настроить сенсоры, но лучше чем ничего.       
Скрин:
![Scrin](https://user-images.githubusercontent.com/85778771/129893632-5ba70ce0-e256-48e3-89e7-775daab69e09.png)
P.S. Добрые люди могут добавить телескрин навигации на ГУП для руботов шахтёров.
