### PR TITLE
Фикс дюпа металлов с голодека

### DIFF
--- a/maps/sierra/sierra-4.dmm
+++ b/maps/sierra/sierra-4.dmm
@@ -7197,7 +7197,8 @@
 /area/holodeck/source_military)
 "aTC" = (
 /obj/structure/bed/chair{
-	dir = 1
+	dir = 1;
+	holographic = 1
 	},
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 8
@@ -7209,7 +7210,8 @@
 /area/holodeck/source_military)
 "aTD" = (
 /obj/structure/bed/chair{
-	dir = 1
+	dir = 1;
+	holographic = 1
 	},
 /obj/effect/floor_decal/corner/black{
 	dir = 4
@@ -7218,7 +7220,8 @@
 /area/holodeck/source_military)
 "aTE" = (
 /obj/structure/bed/chair{
-	dir = 1
+	dir = 1;
+	holographic = 1
 	},
 /obj/effect/floor_decal/corner/black{
 	dir = 1
@@ -7227,7 +7230,8 @@
 /area/holodeck/source_military)
 "aTF" = (
 /obj/structure/bed/chair{
-	dir = 1
+	dir = 1;
+	holographic = 1
 	},
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 4
@@ -7266,7 +7270,8 @@
 /area/holodeck/source_plaza)
 "aUt" = (
 /obj/structure/bed/chair{
-	dir = 1
+	dir = 1;
+	holographic = 1
 	},
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 10
@@ -7275,14 +7280,16 @@
 /area/holodeck/source_military)
 "aUu" = (
 /obj/structure/bed/chair{
-	dir = 1
+	dir = 1;
+	holographic = 1
 	},
 /obj/effect/floor_decal/spline/plain/black,
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_military)
 "aUv" = (
 /obj/structure/bed/chair{
-	dir = 1
+	dir = 1;
+	holographic = 1
 	},
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 6


### PR DESCRIPTION
:cl:
bugfix: Стулья в комнате совещаний голодека стали голограммой, не позволяя разбирать их на металл.
/:cl:
