### PR TITLE
Дополнительное логирование для администрации

### DIFF
--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -199,6 +199,7 @@
 		if(href_list["set_psi_faculty"] && href_list["set_psi_faculty_rank"])
 			current.set_psi_rank(href_list["set_psi_faculty"], text2num(href_list["set_psi_faculty_rank"]))
 			log_and_message_admins("set [key_name(current)]'s [href_list["set_psi_faculty"]] faculty to [text2num(href_list["set_psi_faculty_rank"])].")
+			send2adminirc(":: SET PSI FACULTY :: [key_name_admin(usr)] set [key_name(current)]'s [href_list["set_psi_faculty"]] faculty to [text2num(href_list["set_psi_faculty_rank"])].")  // INF
 			var/datum/admins/admin = GLOB.admins[usr.key]
 			if(istype(admin)) admin.show_player_panel(current)
 			return TRUE
@@ -208,6 +209,7 @@
 		if(antag)
 			if(antag.add_antagonist(src, 1, 1, 0, 1, 1)) // Ignore equipment and role type for this.
 				log_admin("[key_name_admin(usr)] made [key_name(src)] into a [antag.role_text].")
+				send2adminirc(":: ADD ANTAGONIST :: [key_name_admin(usr)] made [key_name(src)] into a [antag.role_text].")  // INF
 			else
 				to_chat(usr, "<span class='warning'>[src] could not be made into a [antag.role_text]!</span>")
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -913,6 +913,7 @@ var/global/floorIsLava = 0
 		SSticker.forced_end = TRUE
 		log_admin("[key_name(usr)] инициировал завершение раунда.")
 		to_world("<span class='danger'>Раунд завершен!</span> <span class='notice'>Инициировано [usr.key].</span>")
+		send2adminirc(":: END ROUND :: [key_name(usr)] инициировал завершение раунда.") // INF
 		SSstatistics.add_field("admin_verb","ER") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else
 		to_chat(usr, FONT_LARGE(SPAN_WARNING("You cannot end the round before it's begun!")))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -169,7 +169,7 @@ var/list/admin_verbs_server = list(
 	// /client/proc/check_customitem_activity,
 	/client/proc/update_server,
 	/client/proc/cmd_toggle_admin_help,
-	/client/proc/observe_delay, 
+	/client/proc/observe_delay,
 	/datum/admins/proc/toggleevent,
 	/client/proc/cmd_set_station_date,
 //[/INF],
@@ -640,6 +640,7 @@ var/list/admin_verbs_xeno = list(
 		usr.PushClickHandler(/datum/click_handler/build_mode)
 	SSstatistics.add_field_details("admin_verb","TBMS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	log_and_message_admins("switched build mode for himself.")
+	send2adminirc("[get_key(src)] switched build mode for himself.")  // INF
 
 /client/proc/object_talk(var/msg as text) // -- TLE
 	set category = "Special Verbs"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -214,9 +214,11 @@
 			if("1")
 				if (evacuation_controller.call_evacuation(usr, TRUE))
 					log_and_message_admins("called an evacuation.")
+					send2adminirc(":: CALL SHUTTLE :: [get_key(usr)] вызвал эвакуацию.")  // INF
 			if("2")
 				if (evacuation_controller.cancel_evacuation())
 					log_and_message_admins("cancelled an evacuation.")
+					send2adminirc(":: CALL SHUTTLE :: [get_key(usr)] отменил эвакуацию.")  // INF
 
 		href_list["secretsadmin"] = "check_antagonist"
 
@@ -225,6 +227,7 @@
 
 		SSticker.delay_end = !SSticker.delay_end
 		log_and_message_admins("[SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].")
+		send2adminirc(":: DELAY ROUND END :: [get_key(usr)] [SSticker.delay_end ? "приостановил конец раунда." : "возобновил конец раунда."].")
 		href_list["secretsadmin"] = "check_antagonist"
 
 	else if(href_list["simplemake"])
@@ -1259,6 +1262,7 @@
 		if(config.allow_admin_rev)
 			L.revive()
 			log_and_message_admins("healed / Revived [key_name(L)]")
+			send2adminirc(":: REJUVINATE :: [get_key(usr)] вылечил / воскресил [get_key(L)]") // INF
 		else
 			to_chat(usr, "Admin Rejuvinates have been disabled")
 
@@ -1311,6 +1315,7 @@
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
 
 		log_and_message_admins("attempting to zombify [key_name_admin(H)]")
+		send2adminirc(":: MAKEZOMBIE :: [get_key(usr)] пытается превратить в зомби [get_key(H)]") // INF
 		H.zombify()
 
 	else if(href_list["togmutate"])


### PR DESCRIPTION

# Описание

Данный пулл-реквест направлен на помощь администрации в логировании раундов и взаимодействии с событиями раунда.

## Основные изменения

* Логирование переключения билд-мода
* Логирование добавления антагонистов
* Логирование конца раунда
* Логирование шаттла
* Логирование отсрочки конца раунда

