### PR TITLE
Autoinjector band color fix

### DIFF
--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -205,25 +205,25 @@ Single Use Emergency Pouches
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline
 	name = "emergency inaprovaline autoinjector"
 	starts_with = list(/datum/reagent/inaprovaline = 5)
-	band_color = "#00bfff"
+	band_color = COLOR_CYAN //inf
 
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/deletrathol
 	name = "emergency deletrathol autoinjector"
 	starts_with = list(/datum/reagent/deletrathol = 5)
-	band_color = "#800080"
+	band_color = COLOR_PURPLE //inf
 
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/dylovene
 	name = "emergency dylovene autoinjector"
 	starts_with = list(/datum/reagent/dylovene = 5)
-	band_color = "#00a000"
+	band_color = COLOR_LIME //inf
 
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/dexalin
 	name = "emergency dexalin autoinjector"
 	starts_with = list(/datum/reagent/dexalin = 5)
-	band_color = "#0080ff"
+	band_color = COLOR_CYAN_BLUE //inf
 
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/adrenaline
 	name = "emergency adrenaline autoinjector"
 	amount_per_transfer_from_this = 8
 	starts_with = list(/datum/reagent/adrenaline = 8)
-	band_color = "#c8a5dc"
+	band_color = COLOR_PURPLE_GRAY //inf

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -205,20 +205,25 @@ Single Use Emergency Pouches
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline
 	name = "emergency inaprovaline autoinjector"
 	starts_with = list(/datum/reagent/inaprovaline = 5)
+	band_color = "#00bfff"
 
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/deletrathol
 	name = "emergency deletrathol autoinjector"
 	starts_with = list(/datum/reagent/deletrathol = 5)
+	band_color = "#800080"
 
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/dylovene
 	name = "emergency dylovene autoinjector"
 	starts_with = list(/datum/reagent/dylovene = 5)
+	band_color = "#00a000"
 
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/dexalin
 	name = "emergency dexalin autoinjector"
 	starts_with = list(/datum/reagent/dexalin = 5)
+	band_color = "#0080ff"
 
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/adrenaline
 	name = "emergency adrenaline autoinjector"
 	amount_per_transfer_from_this = 8
 	starts_with = list(/datum/reagent/adrenaline = 8)
+	band_color = "#c8a5dc"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -163,8 +163,8 @@
 /obj/item/reagent_containers/hypospray/autoinjector
 	name = "autoinjector"
 	desc = "A rapid and safe way to administer small amounts of drugs by untrained or trained personnel."
-	icon = 'icons/obj/syringe_inf.dmi'
-	icon_state = "blue1"
+	icon = 'icons/obj/syringe.dmi'
+	icon_state = "injector"
 	item_state = "autoinjector"
 	amount_per_transfer_from_this = 5
 	volume = 5
@@ -188,7 +188,7 @@
 /obj/item/reagent_containers/hypospray/autoinjector/on_update_icon()
 	overlays.Cut()
 	if(reagents.total_volume > 0)
-		icon_state = "[initial(icon_state)]"
+		icon_state = "[initial(icon_state)]1"
 	else
 		icon_state = "[initial(icon_state)]0"
 	overlays+= overlay_image(icon,"injector_band",band_color,RESET_COLOR)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -202,42 +202,42 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/detox
 	name = "autoinjector (antitox)"
-	band_color = "#00a000"
+	band_color = COLOR_LIME //inf //was: COLOR_GREEN
 	starts_with = list(/datum/reagent/dylovene = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/pain
 	name = "autoinjector (painkiller)"
-	band_color = "#cb68fc"
+	band_color = COLOR_VIOLET //inf //was: COLOR_PURPLE
 	starts_with = list(/datum/reagent/tramadol = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/brute
 	name = "autoinjector (anti-injury)"
-	band_color = "#bf0000"
+	band_color = COLOR_RED //inf //was: COLOR_NT_RED
 	starts_with = list(/datum/reagent/bicaridine = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/burn
 	name = "autoinjector (anti-burn)"
-	band_color = "#ffa800"
+	band_color = COLOR_DARK_ORANGE //inf //was: COLOR_SUN
 	starts_with = list(/datum/reagent/kelotane = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline
 	name = "autoinjector (inaprovaline)"
-	band_color = "#00bfff"
+	band_color = COLOR_CYAN 
 	starts_with = list(/datum/reagent/inaprovaline = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/combatpain
 	name = "autoinjector (oxycodone)"
-	band_color = "#800080"
+	band_color = COLOR_PURPLE //inf //was: COLOR_DARK_GRAY
 	starts_with = list(/datum/reagent/tramadol/oxycodone = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/antirad
 	name = "autoinjector (anti-rad)"
-	band_color = "#408000"
+	band_color = COLOR_GOLD //inf //was: COLOR_AMBER
 	starts_with = list(/datum/reagent/hyronalin = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/mindbreaker
 	name = "autoinjector"
-	band_color = "#b31008"
+	band_color = COLOR_NT_RED //inf //was: COLOR_DARK_GRAY
 	starts_with = list(/datum/reagent/mindbreaker = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/empty

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -245,4 +245,3 @@
 	band_color = COLOR_WHITE
 	starts_with = list()
 	matter = list(MATERIAL_PLASTIC = 150, MATERIAL_GLASS = 50)
-	

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -202,42 +202,42 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/detox
 	name = "autoinjector (antitox)"
-	band_color = COLOR_GREEN
+	band_color = "#00a000"
 	starts_with = list(/datum/reagent/dylovene = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/pain
 	name = "autoinjector (painkiller)"
-	band_color = COLOR_PURPLE
+	band_color = "#cb68fc"
 	starts_with = list(/datum/reagent/tramadol = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/brute
 	name = "autoinjector (anti-injury)"
-	band_color = COLOR_NT_RED
+	band_color = "#bf0000"
 	starts_with = list(/datum/reagent/bicaridine = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/burn
 	name = "autoinjector (anti-burn)"
-	band_color = COLOR_SUN
+	band_color = "#ffa800"
 	starts_with = list(/datum/reagent/kelotane = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline
 	name = "autoinjector (inaprovaline)"
-	band_color = COLOR_SKY_BLUE
+	band_color = "#00bfff"
 	starts_with = list(/datum/reagent/inaprovaline = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/combatpain
 	name = "autoinjector (oxycodone)"
-	band_color = COLOR_DARK_GRAY
+	band_color = "#800080"
 	starts_with = list(/datum/reagent/tramadol/oxycodone = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/antirad
 	name = "autoinjector (anti-rad)"
-	band_color = COLOR_AMBER
+	band_color = "#408000"
 	starts_with = list(/datum/reagent/hyronalin = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/mindbreaker
 	name = "autoinjector"
-	band_color = COLOR_DARK_GRAY
+	band_color = "#b31008"
 	starts_with = list(/datum/reagent/mindbreaker = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/empty
@@ -245,3 +245,4 @@
 	band_color = COLOR_WHITE
 	starts_with = list()
 	matter = list(MATERIAL_PLASTIC = 150, MATERIAL_GLASS = 50)
+	

--- a/infinity/code/modules/reagents/reagents_containers/hypospray.dm
+++ b/infinity/code/modules/reagents/reagents_containers/hypospray.dm
@@ -1,4 +1,4 @@
 /obj/item/reagent_containers/hypospray/autoinjector/stimpack
 	name = "stimpack"
-	band_color = "#ff2681"
+	band_color = COLOR_PINK //inf //was: COLOR_DARK_GRAY
 	starts_with = list(/datum/reagent/nitritozadole = 5)

--- a/infinity/code/modules/reagents/reagents_containers/hypospray.dm
+++ b/infinity/code/modules/reagents/reagents_containers/hypospray.dm
@@ -1,4 +1,4 @@
 /obj/item/reagent_containers/hypospray/autoinjector/stimpack
 	name = "stimpack"
-	band_color = COLOR_DARK_GRAY
+	band_color = "#ff2681"
 	starts_with = list(/datum/reagent/nitritozadole = 5)


### PR DESCRIPTION
Фикс отображения цветовой маркировки у инжекторов

Все инжекторы уже черт знает сколько времени имеют синюю маркировку вне зависимости от содержимого, так быть не должно.

Главная проблема была в некорректной ссылке на иконку старых инжекторов с заранее прорисованной маркировкой, пофиксил путь до правильного спрайта и заменил цвета из палитры на цвет самого химиката. Цвета палитры слишком темные для отображения на маркировочной ленте. Например, дексалин не отличить от ино.

В принципе, мне не принципиально какой именно будет цвет у инжекторов, мне главное чтобы они отличались между собой.


## Changelog

:cl:
bugfix: Фикс полос у инжекторов. Теперь они маркированы цветом своего препарата.
/:cl:
