### PR TITLE
Добавляем Erosan-ящерам флаг SPECIES_IS_RESTRICTED

### DIFF
--- a/infinity/code/modules/species/station/lizard.dm
+++ b/infinity/code/modules/species/station/lizard.dm
@@ -9,6 +9,8 @@
 	limb_blend = ICON_MULTIPLY
 	tail_blend = ICON_MULTIPLY
 
+	spawn_flags = SPECIES_IS_RESTRICTED
+
 //we need to change almost all things below
 /*
 	darksight_range = 3


### PR DESCRIPTION
# Описание

В этом пулл-реквесте Erosan унати получают флаг `SPECIES_IS_RESTRICTED` из-за которого выбрать их в редакторе персонажа нельзя, как и заспавниться без помощи администраторов.
