### PR TITLE
Форсконверт для культа и бафф культоножа

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -131,7 +131,7 @@
 	if(!GLOB.cult.can_become_antag(target.mind, 1))
 		to_chat(target, "<span class='danger'>Are you going insane?</span>")
 	else
-		GLOB.cult.add_antagonist(usr.mind, ignore_role = 1, do_not_equip = 1)
+		GLOB.cult.add_antagonist(target.mind, ignore_role = 1, do_not_equip = 1)
 
 /obj/effect/rune/teleport
 	cultname = "teleport"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -131,31 +131,7 @@
 	if(!GLOB.cult.can_become_antag(target.mind, 1))
 		to_chat(target, "<span class='danger'>Are you going insane?</span>")
 	else
-		to_chat(target, "<span class='cult'>Do you want to join the cult of Nar'Sie? You can choose to ignore offer... <a href='?src=\ref[src];join=1'>Join the cult</a>.</span>")
-
-	spamcheck = 1
-	spawn(40)
-		spamcheck = 0
-		if(!iscultist(target) && target.loc == get_turf(src)) // They hesitated, resisted, or can't join, and they are still on the rune - burn them
-			if(target.stat == CONSCIOUS)
-				target.take_overall_damage(0, 10)
-				switch(target.getFireLoss())
-					if(0 to 25)
-						to_chat(target, "<span class='danger'>Your blood boils as you force yourself to resist the corruption invading every corner of your mind.</span>")
-					if(25 to 45)
-						to_chat(target, "<span class='danger'>Your blood boils and your body burns as the corruption further forces itself into your body and mind.</span>")
-						target.take_overall_damage(0, 3)
-					if(45 to 75)
-						to_chat(target, "<span class='danger'>You begin to hallucinate images of a dark and incomprehensible being and your entire body feels like its engulfed in flame as your mental defenses crumble.</span>")
-						target.take_overall_damage(0, 5)
-					if(75 to 100)
-						to_chat(target, "<span class='cult'>Your mind turns to ash as the burning flames engulf your very soul and images of an unspeakable horror begin to bombard the last remnants of mental resistance.</span>")
-						target.take_overall_damage(0, 10)
-
-/obj/effect/rune/convert/Topic(href, href_list)
-	if(href_list["join"])
-		if(usr.loc == loc && !iscultist(usr))
-			GLOB.cult.add_antagonist(usr.mind, ignore_role = 1, do_not_equip = 1)
+		GLOB.cult.add_antagonist(usr.mind, ignore_role = 1, do_not_equip = 1)
 
 /obj/effect/rune/teleport
 	cultname = "teleport"

--- a/infinity/code/game/gamemodes/cult/cult_items.dm
+++ b/infinity/code/game/gamemodes/cult/cult_items.dm
@@ -79,7 +79,7 @@
 	desc = "A strange dagger, the blade of which is always covered with a thick dark haze."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "render"
-	force = 6
+	force = 15
 	armor_penetration = 100
 	throwforce = 13
 	throw_speed = 1


### PR DESCRIPTION
# Описание
Теперь конверт в культ не требует согласия конвертируемого.
Избавит от ситуация в культе, когда человека принесли в убежище, а он игнорит конверт и всеми силами не хочет стать ролью
Также это более реалистично
Как обычный медик может сопротивляться силе тёмного бога из глубин блюспейса?
И немного баффнул теневой клинок

## Основные изменения

Конверт в культ теперь не спрашивает разрешение
баффнут нож культа, теперь у него урон 15
## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
tweak: forced convert for cult
balance: shadow dagger force now 15, like tgstation
/:cl:
