### PR TITLE
Изоляционки полевому инженеру, ликвидация камеры из душевой вторых дорм

### DIFF
--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -12008,10 +12008,8 @@
 "avs" = (
 /obj/structure/flora/seaweed,
 /obj/structure/flora/seaweed/large,
-/mob/living/simple_animal/aquatic/fish/grump{
-	name = "Titus"
-	},
 /obj/effect/fluid_mapped,
+/mob/living/simple_animal/aquatic/fish,
 /turf/simulated/floor/aquarium,
 /area/crew_quarters/lounge_big)
 "avt" = (
@@ -28384,9 +28382,6 @@
 /area/engineering/engine_monitoring)
 "aYX" = (
 /obj/structure/flora/seaweed/glow,
-/mob/living/simple_animal/aquatic/fish{
-	name = "Marry"
-	},
 /obj/effect/fluid_mapped,
 /turf/simulated/floor/aquarium,
 /area/crew_quarters/lounge_big)
@@ -34530,6 +34525,7 @@
 "dYM" = (
 /obj/structure/flora/seaweed/mid,
 /obj/effect/fluid_mapped,
+/mob/living/simple_animal/aquatic/fish/grump,
 /turf/simulated/floor/aquarium,
 /area/crew_quarters/lounge_big)
 "dZt" = (
@@ -38965,10 +38961,6 @@
 	},
 /obj/effect/floor_decal/spline/fancy/black{
 	dir = 9
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck - Lounge - Restroom Back Entrance";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head_big)

--- a/maps/sierra/structures/closets/exploration.dm
+++ b/maps/sierra/structures/closets/exploration.dm
@@ -151,6 +151,7 @@
 		/obj/item/device/radio/headset/exploration/alt,
 		/obj/item/device/binoculars,
 		/obj/item/clothing/gloves/thick,
+		/obj/item/clothing/glovers/insulated,
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel/grey)),
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag, /obj/item/storage/backpack/messenger)),
 		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/flare/glowstick/random))

--- a/maps/sierra/structures/closets/exploration.dm
+++ b/maps/sierra/structures/closets/exploration.dm
@@ -151,7 +151,7 @@
 		/obj/item/device/radio/headset/exploration/alt,
 		/obj/item/device/binoculars,
 		/obj/item/clothing/gloves/thick,
-		/obj/item/clothing/glovers/insulated,
+		/obj/item/clothing/gloves/insulated,
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel/grey)),
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag, /obj/item/storage/backpack/messenger)),
 		new /datum/atom_creator/weighted(list(/obj/item/device/flashlight, /obj/item/device/flashlight/flare, /obj/item/device/flashlight/flare/glowstick/random))


### PR DESCRIPTION
# Описание

Полевому инженеру подарили второй вид перчаток, а из душевых убрана камера для подглядыванием за людьми в душевых.

## Changelog

:cl:
rscadd: В шкаф полевого инженера добавлены изоляционные перчатки.
maptweak: Камеры из душевых вторых дорм полностью убраны.
/:cl:
