### PR TITLE
Feature/flora can store items

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3465,6 +3465,7 @@
 #include "infinity\code\game\objects\structures\barrier.dm"
 #include "infinity\code\game\objects\structures\barsign.dm"
 #include "infinity\code\game\objects\structures\curtains.dm"
+#include "infinity\code\game\objects\structures\flora.dm"
 #include "infinity\code\game\objects\structures\holoplants.dm"
 #include "infinity\code\game\objects\structures\railing.dm"
 #include "infinity\code\game\objects\structures\signs.dm"

--- a/infinity/code/game/objects/structures/flora.dm
+++ b/infinity/code/game/objects/structures/flora.dm
@@ -1,0 +1,88 @@
+// This code allows players to store items in pots with plants.
+//
+// Pots with plants have two variables:
+// can_store_item - a boolean variable that determines whether a pot can hide an object in itself
+// stored_item - the variable that is responsible for the object hidden in the pot.
+//
+// ported from Aurorastation
+//
+// by SidVeld
+
+
+/obj/structure/flora/pottedplant
+	var/can_store_item = TRUE
+	var/obj/item/stored_item
+
+
+/obj/structure/flora/pottedplant/Destroy()
+	QDEL_NULL(stored_item)
+	return ..()
+
+
+/obj/structure/flora/pottedplant/attackby(obj/item/object, mob/user)
+
+	// Can this pot store items?
+	if (can_store_item)
+		user.visible_message(
+			"[user] begins digging around inside of \the [src].",
+			"You begin digging around in \the [src], trying to hide \the [object]."
+		)
+
+		if (do_after(user, 20, src))
+
+			// Is there a hidden object in the pot?
+			if (!stored_item)
+
+				// Is it too big an object we want to hide?
+				if (object.w_class <= ITEM_SIZE_NORMAL)
+					user.drop_from_inventory(object)
+					object.forceMove(src)
+					stored_item = object
+					to_chat(user, SPAN_NOTICE("You hide \the [object] in [src]."))
+					return
+				else
+					to_chat(user, SPAN_NOTICE("The [object] can't be hidden in [src], it's too big."))
+					return
+
+			else
+				to_chat(user, SPAN_NOTICE("There is something hidden in [src]."))
+				return
+
+	return ..()
+
+
+/obj/structure/flora/pottedplant/attack_hand(mob/user)
+
+	// Can this pot store items?
+	if (can_store_item)
+		user.visible_message(
+			"[user] begins digging around inside of \the [src].",
+			"You begin digging around in \the [src], searching it."
+		)
+
+		if (do_after(user, 40, src))
+			if(!stored_item)
+				to_chat(user, SPAN_NOTICE("There is nothing hidden in [src]."))
+				return
+			else
+				user.put_in_hands(stored_item)
+				stored_item = null
+				to_chat(user, SPAN_NOTICE("You take \the [stored_item] from [src]."))
+				return
+
+
+// This plants can't store items - they are too small
+/obj/structure/flora/pottedplant/smallcactus
+	can_store_item = FALSE
+
+/obj/structure/flora/pottedplant/small
+	can_store_item = FALSE
+
+/obj/structure/flora/pottedplant/shoot
+	can_store_item = FALSE
+
+/obj/structure/flora/pottedplant/deskleaf
+	can_store_item = FALSE
+
+/obj/structure/flora/pottedplant/deskferntrim
+	can_store_item = FALSE

--- a/maps/sierra/sierra-1.dmm
+++ b/maps/sierra/sierra-1.dmm
@@ -7178,16 +7178,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 23
 	},
-/obj/structure/holoplant{
-	plant = "P-Apple Bush";
-	plant_color = "#66ff66"
-	},
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 4
 	},
+/obj/structure/flora/pottedplant,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "lD" = (
@@ -14875,13 +14872,13 @@
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 10
 	},
-/obj/structure/holoplant,
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue/bordercorner2{
 	dir = 8
 	},
+/obj/structure/flora/pottedplant/tropical,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "xs" = (
@@ -16872,13 +16869,13 @@
 	pixel_y = -6;
 	req_access = list("ACCESS_CARGO")
 	},
-/obj/structure/holoplant,
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue/bordercorner2{
 	dir = 1
 	},
+/obj/structure/flora/pottedplant/subterranean,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "AJ" = (

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -11080,7 +11080,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fore)
 "aue" = (
-/obj/structure/holoplant,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11098,6 +11097,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engineering_monitoring)
 "aug" = (
@@ -21325,12 +21325,12 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 23
 	},
-/obj/structure/holoplant,
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 6
 	},
 /obj/effect/floor_decal/borderfloor/corner2,
 /obj/effect/floor_decal/corner/lime/bordercorner2,
+/obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fore)
 "aLW" = (
@@ -21447,9 +21447,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "aMi" = (
-/obj/structure/holoplant{
-	plant = "P-Alien Plant"
-	},
+/obj/structure/flora/pottedplant/orientaltree,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/sleep/bunk)
 "aMk" = (
@@ -35821,6 +35819,7 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/effect/floor_decal/borderfloor/corner2,
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2,
+/obj/structure/flora/pottedplant/smelly,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
 "iah" = (

--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -13046,6 +13046,7 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 8
 	},
+/obj/structure/flora/pottedplant/thinbush,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore_stairwell)
 "axd" = (
@@ -13691,11 +13692,11 @@
 	dir = 4;
 	id = "iaaleft"
 	},
-/obj/structure/holoplant,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/black/border,
 /obj/effect/floor_decal/borderfloorblack/corner2,
 /obj/effect/floor_decal/corner/black/bordercorner2,
+/obj/structure/flora/pottedplant/tall,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/iaa)
 "ayx" = (
@@ -17769,7 +17770,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/structure/holoplant,
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 8
 	},
@@ -17782,6 +17782,7 @@
 /obj/effect/floor_decal/corner/lime/bordercorner2{
 	dir = 8
 	},
+/obj/structure/flora/pottedplant/bamboo,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/dungeon_master_lounge)
 "aDX" = (
@@ -21685,7 +21686,6 @@
 	dir = 4;
 	pixel_x = -32
 	},
-/obj/structure/holoplant,
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 8
 	},


### PR DESCRIPTION
# Описание

Данный пулл-реквест добавляет напольным цветочным горшкам с растениями возможность прятать в себе вещи. Это даст игрокам возможность делать свои ~~клады~~ заначки, а антагонистам - дополнительные места, в которых должны в прямом смысле покопаться их противники.

**Чтобы спрятать предмет в горшке, игроку нужно сделать следующее:**

* Подойти к цветному горшку
* Кликнуть по нему каким-нибудь предметом
* После небольшой задержки предмет будет спрятан в горшке

**Чтобы достать предмет из горшка, игроку нужно:**

* Подойти к цветному горшку
* Кликнуть по нему пустой рукой
* После небольшой задержки предмет окажется в руках персонажа

**Условия:**

* Предмет должен быть *нормального* или *меньше* размера
* В горшке не должно быть уже спрятанных предметов

## Основные изменения

* Цветные горшки получили возможность прятать в себе вещи
* На Сьерре добавилось несколько растений

## Changelog

:cl:
rscadd: В напольных цветочных горшках можно прятать предметы.
maptweak: На Сьерру были добавлены дополнительные цветочные горшки.
/:cl:
