### PR TITLE
Починена дальность

### DIFF
--- a/code/modules/spells/targeted/equip/shield.dm
+++ b/code/modules/spells/targeted/equip/shield.dm
@@ -6,7 +6,7 @@
 	invocation = "Sia helda!"
 	invocation_type = SpI_SHOUT
 	spell_flags = INCLUDEUSER | NEEDSCLOTHES
-	range = -1
+	range = 0
 	max_targets = 1
 
 	compatible_mobs = list(/mob/living/carbon/human)


### PR DESCRIPTION
Из-за низкой дальности, спелл не находил мага и проваливался из-за отсутствия целей. Дальность была установлена на ноль, позволяя применять заклинание нормально.