### PR TITLE
Починена дальность

### DIFF
--- a/code/modules/spells/targeted/equip/dyrnwyn.dm
+++ b/code/modules/spells/targeted/equip/dyrnwyn.dm
@@ -9,7 +9,7 @@
 	invocation = "Anrhydeddu Fi!"
 	invocation_type = SpI_SHOUT
 	spell_flags = INCLUDEUSER
-	range = -1
+	range = 0
 	level_max = list(Sp_TOTAL = 1, Sp_SPEED = 0, Sp_POWER = 1)
 	duration = 300 //30 seconds
 	max_targets = 1


### PR DESCRIPTION
Из-за низкой дальности, спелл не находил мага и проваливался из-за отсутствия целей. Дальность была установлена на ноль, позволяя применять заклинание нормально.
P.S. Меч всё ещё говно.